### PR TITLE
Make Aether Wayland-first while preserving Omarchy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A visual theming application for [Omarchy](https://omarchy.org). Extract colors 
 - Export themes as shareable packages with selective app inclusion
 
 ### Application Support
-- 20+ pre-configured apps: Hyprland, Waybar, Kitty, Alacritty, Ghostty, Neovim, VS Code, Zed, btop, and more
+- 20+ pre-configured apps: Hyprland, Triad, Waybar, Kitty, Alacritty, Ghostty, Neovim, VS Code, Zed, btop, and more
 - Template system with hex, RGB, RGBA, and stripped format modifiers
 - Per-app overrides, reload hooks, and post-apply scripts
 - Add your own apps with custom templates

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ https://github.com/user-attachments/assets/862377df-ad05-48de-a0a3-65b243c4b44b
 
 # Aether
 
-A visual theming application for [Omarchy](https://omarchy.org). Extract colors from wallpapers and apply cohesive themes across your entire desktop.
+A visual theme generator for Wayland desktops. Aether extracts colors from wallpapers and writes matching theme files for terminals, bars, launchers, editors, and desktop tools.
 
-> **Not using Omarchy?** Aether works standalone on any Linux desktop. See the [Standalone Guide](docs/standalone.md) for setup.
+It works well with [Omarchy](https://omarchy.org), but it does not require Omarchy. See the [Standalone Guide](docs/standalone.md) for a plain Wayland setup.
 
 ## Features
 
@@ -30,12 +30,12 @@ A visual theming application for [Omarchy](https://omarchy.org). Extract colors 
 - 24 built-in color presets including Dracula, Nord, Gruvbox, Catppuccin, and Sakura
 - Import 250+ community Base16 color schemes
 - Save and restore complete themes as blueprint files
-- Export desktop-neutral Aether theme packs with selective app inclusion
+- Export portable Aether theme packs with selective app inclusion
 
 ### Application Support
 - 20+ pre-configured apps: Hyprland, Triad, Zellij, Waybar, Kitty, Alacritty, Ghostty, Neovim, VS Code, Zed, btop, and more
 - Template system with hex, RGB, RGBA, and stripped format modifiers
-- Per-app overrides, reload hooks, and post-apply scripts
+- Per-app overrides and post-apply scripts
 - Add your own apps with custom templates
 
 ### Extras

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ A visual theming application for [Omarchy](https://omarchy.org). Extract colors 
 - 24 built-in color presets including Dracula, Nord, Gruvbox, Catppuccin, and Sakura
 - Import 250+ community Base16 color schemes
 - Save and restore complete themes as blueprint files
-- Export themes as shareable packages with selective app inclusion
+- Export desktop-neutral Aether theme packs with selective app inclusion
 
 ### Application Support
-- 20+ pre-configured apps: Hyprland, Triad, Waybar, Kitty, Alacritty, Ghostty, Neovim, VS Code, Zed, btop, and more
+- 20+ pre-configured apps: Hyprland, Triad, Zellij, Waybar, Kitty, Alacritty, Ghostty, Neovim, VS Code, Zed, btop, and more
 - Template system with hex, RGB, RGBA, and stripped format modifiers
 - Per-app overrides, reload hooks, and post-apply scripts
 - Add your own apps with custom templates

--- a/app.go
+++ b/app.go
@@ -843,7 +843,7 @@ var allExportableApps = map[string]bool{
 	"alacritty": true, "btop": true, "chromium": true, "colors": true,
 	"foot": true, "ghostty": true, "gtk": true, "hyprland": true, "hyprlock": true,
 	"icons": true, "kitty": true, "mako": true, "neovim": true,
-	"swayosd": true, "vencord": true, "vscode": true, "walker": true,
+	"swayosd": true, "triad": true, "vencord": true, "vscode": true, "walker": true,
 	"warp": true, "waybar": true, "wofi": true, "zed": true,
 }
 

--- a/app.go
+++ b/app.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"aether/internal/batch"
 	"aether/internal/blueprint"
@@ -20,6 +21,7 @@ import (
 	"aether/internal/platform"
 	"aether/internal/template"
 	"aether/internal/theme"
+	"aether/internal/themepack"
 	"aether/internal/wallhaven"
 	"aether/internal/wallpaper"
 	"aether/ipc"
@@ -834,6 +836,7 @@ type ExportThemeRequest struct {
 	LightMode        bool                         `json:"lightMode"`
 	AdditionalImages []string                     `json:"additionalImages"`
 	ExtendedColors   map[string]string            `json:"extendedColors"`
+	Adjustments      map[string]float64           `json:"adjustments"`
 	InstallToOmarchy bool                         `json:"installToOmarchy"`
 	AppOverrides     map[string]map[string]string `json:"appOverrides"`
 }
@@ -844,7 +847,7 @@ var allExportableApps = map[string]bool{
 	"foot": true, "ghostty": true, "gtk": true, "hyprland": true, "hyprlock": true,
 	"icons": true, "kitty": true, "mako": true, "neovim": true,
 	"swayosd": true, "triad": true, "vencord": true, "vscode": true, "walker": true,
-	"warp": true, "waybar": true, "wofi": true, "zed": true,
+	"warp": true, "waybar": true, "wofi": true, "zed": true, "zellij": true,
 }
 
 // ExportTheme exports the current theme to a user-chosen directory.
@@ -904,9 +907,32 @@ func (a *App) ExportTheme(req ExportThemeRequest) (string, error) {
 		ExcludedApps:  excluded,
 	}
 
-	exportDir := filepath.Join(dir, "omarchy-"+slug+"-theme")
+	exportDir := filepath.Join(dir, "aether-"+slug+"-theme-pack")
 	if err := a.writer.GenerateOnly(state, settings, exportDir); err != nil {
 		return "", fmt.Errorf("export failed: %w", err)
+	}
+
+	packWallpaper := relativePackPath(req.WallpaperPath)
+	packImages := relativePackPaths(req.AdditionalImages)
+	packBlueprint := &blueprint.Blueprint{
+		Name: req.Name,
+		Palette: blueprint.PaletteData{
+			Colors:           req.Palette,
+			Wallpaper:        packWallpaper,
+			LightMode:        req.LightMode,
+			ExtendedColors:   req.ExtendedColors,
+			AdditionalImages: packImages,
+		},
+		Adjustments:  req.Adjustments,
+		AppOverrides: req.AppOverrides,
+		Timestamp:    time.Now().UnixMilli(),
+	}
+	manifest, err := themepack.NewManifest(exportDir, req.Name, slug, req.IncludedApps, req.LightMode, packWallpaper, packImages)
+	if err != nil {
+		return "", fmt.Errorf("theme pack manifest failed: %w", err)
+	}
+	if err := themepack.Write(exportDir, manifest, packBlueprint); err != nil {
+		return "", fmt.Errorf("theme pack metadata failed: %w", err)
 	}
 
 	if req.InstallToOmarchy && theme.IsOmarchyInstalled() {
@@ -919,6 +945,23 @@ func (a *App) ExportTheme(req ExportThemeRequest) (string, error) {
 	}
 
 	return exportDir, nil
+}
+
+func relativePackPath(src string) string {
+	if src == "" || strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		return src
+	}
+	return filepath.ToSlash(filepath.Join("backgrounds", filepath.Base(src)))
+}
+
+func relativePackPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if rel := relativePackPath(p); rel != "" {
+			out = append(out, rel)
+		}
+	}
+	return out
 }
 
 // ImportResult is returned by ImportFileDialog with the imported colors.
@@ -957,6 +1000,13 @@ func (a *App) ImportFileDialog(fileType string) (*ImportResult, error) {
 			{DisplayName: "JSON Files", Pattern: "*.json"},
 			{DisplayName: "All Files", Pattern: "*"},
 		}
+	case "theme-pack":
+		title = "Import Theme Pack"
+		filters = []wailsrt.FileFilter{
+			{DisplayName: "Aether Theme Pack", Pattern: "aether-theme-pack.json;blueprint.json"},
+			{DisplayName: "JSON Files", Pattern: "*.json"},
+			{DisplayName: "All Files", Pattern: "*"},
+		}
 	default:
 		return nil, fmt.Errorf("unknown file type: %s", fileType)
 	}
@@ -988,6 +1038,8 @@ func (a *App) importFile(path, fileType string) (*ImportResult, error) {
 		bp, err = blueprint.ImportColorsToml(path)
 	case "blueprint":
 		bp, err = blueprint.ImportJSON(path)
+	case "theme-pack":
+		bp, err = themepack.Import(path)
 	default:
 		return nil, fmt.Errorf("unknown type: %s", fileType)
 	}

--- a/app.go
+++ b/app.go
@@ -684,8 +684,8 @@ func (a *App) LoadOmarchyThemes() ([]omarchy.Theme, error) {
 	return omarchy.LoadAllThemes()
 }
 
-// ApplyOmarchyThemeByName activates an existing Omarchy theme directly
-// by running "omarchy-theme-set <name>" without processing through Aether templates.
+// ApplyOmarchyThemeByName activates an existing Omarchy theme directly.
+// Portable Aether packs use ApplyTheme instead.
 func (a *App) ApplyOmarchyThemeByName(name string) error {
 	_, err := platform.RunSync("omarchy-theme-set", name)
 	return err
@@ -937,7 +937,7 @@ func (a *App) ExportTheme(req ExportThemeRequest) (string, error) {
 
 	if req.InstallToOmarchy && theme.IsOmarchyInstalled() {
 		linkPath := filepath.Join(platform.OmarchyThemesDir(), slug)
-		if err := platform.CreateSymlink(exportDir, linkPath); err != nil {
+		if err := platform.ReplaceSymlink(exportDir, linkPath); err != nil {
 			log.Printf("Warning: could not symlink to omarchy themes: %v", err)
 		} else {
 			log.Printf("Installed as omarchy theme: %s -> %s", linkPath, exportDir)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -261,7 +261,7 @@ Aether launches `aether-wp` automatically when you apply a theme with an animate
 
 **How it works:**
 
-- Renders on the background layer via `gtk-layer-shell` (replaces `swaybg`)
+- Renders on the background layer via `gtk-layer-shell`
 - GPU-accelerated playback using `gtkglsink` (OpenGL), auto-falls back to `gtksink` (CPU)
 - Frame rate capped at 30fps to reduce GPU load
 - Loops automatically on end-of-stream
@@ -280,7 +280,9 @@ Aether launches `aether-wp` automatically when you apply a theme with an animate
 1. Same directory as the `aether` binary
 2. `$PATH`
 
-When applying a static wallpaper, Aether automatically kills any running `aether-wp` process and falls back to `swaybg`.
+When applying a static wallpaper, Aether stops its own `aether-wp` process. If
+the wallpaper backend is `swaybg`, it also stops only the `swaybg` process that
+Aether started.
 
 ## Color Utilities
 
@@ -610,14 +612,15 @@ Aether respects standard XDG directories:
 ### `AETHER_EXTRA_THEME_DIRS`
 
 Colon-separated list of additional directories to scan for themes shown
-in the **System Themes** tab. These are searched **before** the omarchy
-defaults (`~/.config/omarchy/themes`, `~/.local/share/omarchy/themes`,
-`~/.config/themes`), so a theme with the same name in a custom directory
-wins.
+in the **System Themes** tab. These are searched before the default theme
+locations: `~/.config/omarchy/themes`, `~/.local/share/omarchy/themes`, and
+`~/.config/themes`.
 
 ```bash
 AETHER_EXTRA_THEME_DIRS="$HOME/dotfiles/themes:$HOME/work/themes" aether
 ```
 
-Useful if you keep themes in a non-omarchy location (e.g. your dotfiles
-repo) or run a distro that puts themes elsewhere.
+Use this when you keep portable Aether theme packs in a dotfiles repo or another
+nonstandard directory. Aether skips its own generated output at
+`~/.config/aether/theme`, so the picker shows real packs rather than the last
+theme Aether wrote.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+Aether's maintained target is Linux on Wayland.
+
 ## Requirements
 
 - **Go** 1.23+
@@ -27,35 +29,6 @@ sudo apt-get install -f
 ```
 
 The `.deb` package includes both `aether` and `aether-wp` binaries and pulls in all required dependencies automatically.
-
-## macOS
-
-### Requirements
-
-- **Go** 1.23+
-- **Wails CLI** (`go install github.com/wailsapp/wails/v2/cmd/wails@latest`)
-- **Node.js** 18+
-- **ffmpeg** (for video thumbnail and color extraction): `brew install ffmpeg`
-- **Xcode Command Line Tools**: `xcode-select --install`
-
-### Build
-
-```bash
-git clone https://github.com/bjarneo/aether.git
-cd aether && make build
-```
-
-This builds `aether` as a macOS app in `build/bin/`. The animated wallpaper service (`aether-wp`) is Linux-only and is skipped on macOS.
-
-### Install
-
-```bash
-make install
-```
-
-This copies the app to `/Applications/Aether.app` or the binary to `/usr/local/bin/aether`.
-
-Aether runs in **standalone mode** on macOS — theme files are generated but not applied system-wide. See [Standalone Usage](standalone.md) for integration details.
 
 ## Build from Source
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,8 +1,6 @@
-# Standalone Usage (Non-Omarchy Systems)
+# Standalone Wayland Usage
 
-Aether can be used on any Linux or macOS system, not just Omarchy. When running outside of Omarchy, theme files are generated to Aether's config directory and can be included by whichever desktop, terminal, editor, or widget system you use.
-
-On macOS, theme files are generated to `~/Library/Application Support/aether/theme/`.
+Aether does not require Omarchy. On a plain Wayland session, it writes theme files to Aether's config directory. Your compositor, terminal, bar, launcher, and editor can include those files directly.
 
 ## Theme Output Location
 
@@ -79,12 +77,12 @@ Or symlink it:
 ln -sf ~/.config/aether/theme/waybar.css ~/.config/waybar/colors.css
 ```
 
-### Rofi
+### Wofi
 
-Reference the theme in your rofi config:
+Use the generated stylesheet from your Wofi config:
 
-```conf
-@theme "~/.config/aether/theme/rofi.rasi"
+```css
+@import url("file:///home/YOUR_USER/.config/aether/theme/wofi.css");
 ```
 
 ### Neovim
@@ -97,8 +95,9 @@ dofile(vim.fn.expand("~/.config/aether/theme/neovim.lua"))
 
 ### Wallpaper
 
-On Wayland systems that use `awww`, Aether can set the wallpaper when you apply
-a theme. In Settings, choose **Wallpaper: Awww**.
+On Wayland systems, Aether can set the wallpaper when you apply a theme. In
+Settings, choose **Wallpaper: Awww** or **Wallpaper: Swaybg**. **Auto** uses
+Omarchy when it is installed, then `awww`, then `swaybg`.
 
 The generated wallpaper is still written to:
 
@@ -106,8 +105,8 @@ The generated wallpaper is still written to:
 ~/.config/aether/theme/backgrounds/
 ```
 
-If you prefer to manage wallpapers yourself, choose **Wallpaper: None**. A
-manual `swaybg` setup still works:
+If you prefer to manage wallpapers yourself, choose **Wallpaper: None**. A manual
+`swaybg` setup still works:
 
 ```bash
 swaybg -i ~/.config/aether/theme/backgrounds/wallpaper.jpg -m fill
@@ -134,8 +133,12 @@ aether-my-theme-theme-pack/
 └── ...                     # Selected app templates
 ```
 
-Theme packs are desktop-neutral. They can still be installed as Omarchy themes
-when Omarchy is available, but the exported directory does not require Omarchy.
+Theme packs are portable. They can still be installed as Omarchy themes when
+Omarchy is available, but the exported directory does not require Omarchy.
+
+Aether also scans `~/.config/themes` for portable packs. A pack placed there
+appears in the System Themes picker and applies through Aether's normal template
+and wallpaper path.
 
 To import one, choose **Import → Theme Pack** and select either
 `aether-theme-pack.json` or `blueprint.json` inside the pack. Wallpaper paths

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,6 +1,6 @@
 # Standalone Usage (Non-Omarchy Systems)
 
-Aether can be used on any Linux or macOS system, not just Omarchy. When running outside of Omarchy, theme files are generated but not automatically applied system-wide.
+Aether can be used on any Linux or macOS system, not just Omarchy. When running outside of Omarchy, theme files are generated to Aether's config directory and can be included by whichever desktop, terminal, editor, or widget system you use.
 
 On macOS, theme files are generated to `~/Library/Application Support/aether/theme/`.
 
@@ -118,6 +118,28 @@ Or add to your Hyprland config:
 ```conf
 exec-once = swaybg -i ~/.config/aether/theme/backgrounds/wallpaper.jpg -m fill
 ```
+
+## Theme Packs
+
+The editor's **Export** action creates a portable Aether theme pack:
+
+```
+aether-my-theme-theme-pack/
+├── aether-theme-pack.json  # Pack manifest
+├── blueprint.json          # Palette, wallpaper reference, overrides, and adjustments
+├── colors.toml
+├── triad.kdl
+├── zellij.kdl
+├── backgrounds/
+└── ...                     # Selected app templates
+```
+
+Theme packs are desktop-neutral. They can still be installed as Omarchy themes
+when Omarchy is available, but the exported directory does not require Omarchy.
+
+To import one, choose **Import → Theme Pack** and select either
+`aether-theme-pack.json` or `blueprint.json` inside the pack. Wallpaper paths
+inside a pack are resolved relative to that pack directory.
 
 ## GTK Theming
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -95,9 +95,19 @@ Load the colorscheme in your Neovim config:
 dofile(vim.fn.expand("~/.config/aether/theme/neovim.lua"))
 ```
 
-### Wallpaper (swaybg)
+### Wallpaper
 
-Set the wallpaper manually:
+On Wayland systems that use `awww`, Aether can set the wallpaper when you apply
+a theme. In Settings, choose **Wallpaper: Awww**.
+
+The generated wallpaper is still written to:
+
+```bash
+~/.config/aether/theme/backgrounds/
+```
+
+If you prefer to manage wallpapers yourself, choose **Wallpaper: None**. A
+manual `swaybg` setup still works:
 
 ```bash
 swaybg -i ~/.config/aether/theme/backgrounds/wallpaper.jpg -m fill

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -19,6 +19,7 @@ When you click "Apply Theme", Aether generates all theme files to:
 ├── backgrounds/          # Wallpaper copy
 │   └── wallpaper.jpg
 ├── hyprland.conf         # Hyprland color config
+├── triad.kdl             # Triad theme include
 ├── kitty.conf            # Kitty terminal theme
 ├── waybar.css            # Waybar stylesheet
 ├── gtk.css               # GTK theme (if enabled)
@@ -38,6 +39,23 @@ Source the generated config in your `~/.config/hypr/hyprland.conf`:
 ```conf
 source = ~/.config/aether/theme/hyprland.conf
 ```
+
+### Triad
+
+Include the generated theme file in your `~/.config/triad/config.kdl`:
+
+```kdl
+include optional=#true "~/.config/aether/theme/triad.kdl"
+```
+
+Aether writes `theme.accent-color` for Triad. Your explicit Triad colors still
+win, so you can keep custom border, tab, toast, or recent-window colors in your
+main config.
+
+The optional include lets Triad start before Aether has generated a theme. After
+the file exists, Triad watches it with the rest of your config. If you add the
+include for the first time during a running session, run `triad msg config-reload`
+once.
 
 ### Kitty Terminal
 

--- a/frontend/src/lib/components/blueprints/OmarchyThemes.svelte
+++ b/frontend/src/lib/components/blueprints/OmarchyThemes.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
     import {onMount} from 'svelte';
-    import {setPalette, setWallpaperPath} from '$lib/stores/theme.svelte';
+    import {
+        setAdditionalImages,
+        setPalette,
+        setWallpaperPath,
+    } from '$lib/stores/theme.svelte';
     import {setActiveTab, showToast} from '$lib/stores/ui.svelte';
     import {
         getCachedThumbnail,
@@ -9,6 +13,7 @@
     import type {omarchy} from '../../../../wailsjs/go/models';
     import EmptyState from '$lib/components/shared/EmptyState.svelte';
     import LoadingState from '$lib/components/shared/LoadingState.svelte';
+    import {applyTheme} from '$lib/actions/themeActions';
 
     type Theme = omarchy.Theme;
 
@@ -45,6 +50,9 @@
         setPalette(theme.colors);
         if (theme.wallpapers?.length > 0) {
             setWallpaperPath(theme.wallpapers[0]);
+            setAdditionalImages(theme.wallpapers.slice(1));
+        } else {
+            setAdditionalImages([]);
         }
         return true;
     }
@@ -57,8 +65,17 @@
     }
 
     async function handleApply(theme: Theme) {
-        if (theme.colors?.length >= 16) {
-            loadThemeIntoState(theme);
+        if (theme.applyMode === 'aether') {
+            if (!loadThemeIntoState(theme)) {
+                showToast('Theme has no usable palette');
+                return;
+            }
+            await applyTheme();
+            return;
+        }
+        if (theme.applyMode !== 'omarchy') {
+            showToast('Theme has no usable apply path');
+            return;
         }
         try {
             const {ApplyOmarchyThemeByName} = await import(
@@ -77,7 +94,7 @@
 {:else if themes.length === 0}
     <EmptyState
         title="No system themes found"
-        body="Install Omarchy to use bundled system themes, or save your own theme as a Blueprint."
+        body="Add portable Aether theme packs to ~/.config/themes, or install Omarchy themes."
     >
         {#snippet icon()}
             <svg
@@ -144,6 +161,11 @@
                         {#if theme.isCurrentTheme}
                             <span class="text-accent ml-1 text-[10px]"
                                 >current</span
+                            >
+                        {/if}
+                        {#if theme.applyMode === 'aether'}
+                            <span class="text-fg-dimmed ml-1 text-[10px]"
+                                >pack</span
                             >
                         {/if}
                     </div>

--- a/frontend/src/lib/components/layout/ActionBar.svelte
+++ b/frontend/src/lib/components/layout/ActionBar.svelte
@@ -92,6 +92,7 @@
                 {key: 'ghostty', name: 'Ghostty'},
                 {key: 'kitty', name: 'Kitty'},
                 {key: 'warp', name: 'Warp'},
+                {key: 'zellij', name: 'Zellij'},
             ],
         },
         {
@@ -103,6 +104,7 @@
                 {key: 'icons', name: 'Icons'},
                 {key: 'mako', name: 'Mako'},
                 {key: 'swayosd', name: 'SwayOSD'},
+                {key: 'triad', name: 'Triad'},
                 {key: 'walker', name: 'Walker'},
                 {key: 'waybar', name: 'Waybar'},
                 {key: 'wofi', name: 'Wofi'},
@@ -212,17 +214,22 @@
                 lightMode: getLightMode(),
                 additionalImages: getAdditionalImages(),
                 extendedColors: getExtendedColors(),
+                adjustments: getAdjustments() as unknown as Record<
+                    string,
+                    number
+                >,
                 installToOmarchy,
                 appOverrides: getAppOverrides(),
             });
-            // Path ends with .../omarchy-{slug}-theme — pull the slug so the
-            // user can see what name actually went into Omarchy's menu.
+            // Path ends with .../aether-{slug}-theme-pack — pull the slug so
+            // the user can see what name went into optional integrations.
             const slug =
-                path.match(/omarchy-(.+)-theme$/)?.[1] ?? exportName.trim();
+                path.match(/aether-(.+)-theme-pack$/)?.[1] ??
+                exportName.trim();
             showToast(
                 installToOmarchy
                     ? `Installed as Omarchy theme: ${slug}`
-                    : `Exported to ${path}`
+                    : `Exported theme pack to ${path}`
             );
             showExportDialog = false;
             exportName = '';
@@ -345,6 +352,11 @@
                                 class="text-fg-secondary hover:text-fg-primary hover:bg-bg-hover w-full px-3 py-1.5 text-left text-[11px] transition-colors"
                                 onclick={() => handleImport('toml')}
                                 >Colors (.toml)</button
+                            >
+                            <button
+                                class="text-fg-secondary hover:text-fg-primary hover:bg-bg-hover w-full px-3 py-1.5 text-left text-[11px] transition-colors"
+                                onclick={() => handleImport('theme-pack')}
+                                >Theme Pack</button
                             >
                             <button
                                 class="text-fg-secondary hover:text-fg-primary hover:bg-bg-hover w-full px-3 py-1.5 text-left text-[11px] transition-colors"
@@ -523,7 +535,9 @@
     onclose={() => (showExportDialog = false)}
     panelClass="w-80 max-h-[80vh] overflow-y-auto"
 >
-    <h3 class="text-fg-primary mb-3 text-[12px] font-medium">Export Theme</h3>
+    <h3 class="text-fg-primary mb-3 text-[12px] font-medium">
+        Export Theme Pack
+    </h3>
     <input
         bind:this={exportNameInput}
         type="text"

--- a/frontend/src/lib/components/sidebar/TemplateToggles.svelte
+++ b/frontend/src/lib/components/sidebar/TemplateToggles.svelte
@@ -32,6 +32,7 @@
         {value: 'auto', label: 'Auto'},
         {value: 'omarchy', label: 'Omarchy'},
         {value: 'awww', label: 'Awww'},
+        {value: 'swaybg', label: 'Swaybg'},
         {value: 'none', label: 'None'},
     ] as const;
 
@@ -125,7 +126,7 @@
         Wallpaper
     </h3>
     <div class="flex flex-col gap-2">
-        <div class="grid grid-cols-4 gap-1">
+        <div class="grid grid-cols-5 gap-1">
             {#each wallpaperBackends as backend}
                 {@const active = getSettings().wallpaperBackend === backend.value}
                 <button

--- a/frontend/src/lib/components/sidebar/TemplateToggles.svelte
+++ b/frontend/src/lib/components/sidebar/TemplateToggles.svelte
@@ -28,6 +28,13 @@
         {key: 'includeVscode', label: 'VS Code'},
     ] as const;
 
+    const wallpaperBackends = [
+        {value: 'auto', label: 'Auto'},
+        {value: 'omarchy', label: 'Omarchy'},
+        {value: 'awww', label: 'Awww'},
+        {value: 'none', label: 'None'},
+    ] as const;
+
     let appList = $state<string[]>([]);
 
     onMount(async () => {
@@ -115,9 +122,26 @@
     <h3
         class="text-fg-dimmed mb-2 text-[10px] font-medium uppercase tracking-wider"
     >
-        Video Wallpaper
+        Wallpaper
     </h3>
     <div class="flex flex-col gap-2">
+        <div class="grid grid-cols-4 gap-1">
+            {#each wallpaperBackends as backend}
+                {@const active = getSettings().wallpaperBackend === backend.value}
+                <button
+                    type="button"
+                    class="border px-2 py-1 text-[10px] transition-colors duration-100 {active
+                        ? 'bg-accent-muted border-accent text-accent'
+                        : 'border-border text-fg-dimmed hover:text-fg-secondary hover:border-border-focus'}"
+                    aria-pressed={active}
+                    onclick={() =>
+                        updateSettings({wallpaperBackend: backend.value})}
+                >
+                    {backend.label}
+                </button>
+            {/each}
+        </div>
+
         {@render toggleRow(
             'CPU rendering',
             getSettings().videoCpuMode,

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -8,6 +8,7 @@ const defaults: Settings = {
     includeNeovim: true,
     selectedNeovimConfig: '',
     videoCpuMode: false,
+    wallpaperBackend: 'auto',
     excludedApps: {},
 };
 

--- a/frontend/src/lib/types/theme.ts
+++ b/frontend/src/lib/types/theme.ts
@@ -69,7 +69,7 @@ export interface Settings {
     includeNeovim: boolean;
     selectedNeovimConfig: string;
     videoCpuMode: boolean;
-    wallpaperBackend: 'auto' | 'omarchy' | 'awww' | 'none';
+    wallpaperBackend: 'auto' | 'omarchy' | 'awww' | 'swaybg' | 'none';
     // Per-app skip list. Keys are the app names returned by
     // GetTemplateColors (alacritty, hyprland, …). True = skip the
     // template during ApplyTheme / GenerateOnly.

--- a/frontend/src/lib/types/theme.ts
+++ b/frontend/src/lib/types/theme.ts
@@ -69,6 +69,7 @@ export interface Settings {
     includeNeovim: boolean;
     selectedNeovimConfig: string;
     videoCpuMode: boolean;
+    wallpaperBackend: 'auto' | 'omarchy' | 'awww' | 'none';
     // Per-app skip list. Keys are the app names returned by
     // GetTemplateColors (alacritty, hyprland, …). True = skip the
     // template during ApplyTheme / GenerateOnly.

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -187,6 +187,7 @@ export namespace main {
         lightMode: boolean;
         additionalImages: string[];
         extendedColors: Record<string, string>;
+        adjustments: Record<string, number>;
         installToOmarchy: boolean;
         appOverrides: Record<string, any>;
 
@@ -203,6 +204,7 @@ export namespace main {
             this.lightMode = source['lightMode'];
             this.additionalImages = source['additionalImages'];
             this.extendedColors = source['extendedColors'];
+            this.adjustments = source['adjustments'];
             this.installToOmarchy = source['installToOmarchy'];
             this.appOverrides = source['appOverrides'];
         }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -325,6 +325,8 @@ export namespace omarchy {
     export class Theme {
         name: string;
         path: string;
+        source: string;
+        applyMode: string;
         colors: string[];
         background: string;
         foreground: string;
@@ -341,6 +343,8 @@ export namespace omarchy {
             if ('string' === typeof source) source = JSON.parse(source);
             this.name = source['name'];
             this.path = source['path'];
+            this.source = source['source'];
+            this.applyMode = source['applyMode'];
             this.colors = source['colors'];
             this.background = source['background'];
             this.foreground = source['foreground'];

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -432,6 +432,7 @@ export namespace theme {
         selectedNeovimConfig: string;
         excludedApps?: Record<string, boolean>;
         videoCpuMode: boolean;
+        wallpaperBackend: string;
 
         static createFrom(source: any = {}) {
             return new Settings(source);
@@ -446,6 +447,7 @@ export namespace theme {
             this.selectedNeovimConfig = source['selectedNeovimConfig'];
             this.excludedApps = source['excludedApps'];
             this.videoCpuMode = source['videoCpuMode'];
+            this.wallpaperBackend = source['wallpaperBackend'];
         }
     }
     export class StateSnapshot {

--- a/internal/blueprint/import_test.go
+++ b/internal/blueprint/import_test.go
@@ -1,6 +1,8 @@
-package blueprint
+package blueprint_test
 
 import (
+	"aether/internal/blueprint"
+
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +43,7 @@ color15 = "#c0caf5"
 `
 	os.WriteFile(path, []byte(content), 0644)
 
-	bp, err := ImportColorsToml(path)
+	bp, err := blueprint.ImportColorsToml(path)
 	if err != nil {
 		t.Fatalf("ImportColorsToml failed: %v", err)
 	}
@@ -74,7 +76,7 @@ func TestImportColorsTomlFromThemeDir(t *testing.T) {
 	data, _ := os.ReadFile(path)
 	t.Logf("File contents (first 300 bytes):\n%s", string(data)[:min(300, len(data))])
 
-	bp, err := ImportColorsToml(path)
+	bp, err := blueprint.ImportColorsToml(path)
 	if err != nil {
 		t.Fatalf("ImportColorsToml failed: %v", err)
 	}
@@ -106,7 +108,7 @@ func TestImportJSON_BoolLockedColors(t *testing.T) {
 	}`
 	os.WriteFile(path, []byte(content), 0644)
 
-	bp, err := ImportJSON(path)
+	bp, err := blueprint.ImportJSON(path)
 	if err != nil {
 		t.Fatalf("ImportJSON failed: %v", err)
 	}
@@ -138,7 +140,7 @@ func TestImportJSON_IntLockedColors(t *testing.T) {
 	}`
 	os.WriteFile(path, []byte(content), 0644)
 
-	bp, err := ImportJSON(path)
+	bp, err := blueprint.ImportJSON(path)
 	if err != nil {
 		t.Fatalf("ImportJSON failed: %v", err)
 	}
@@ -166,7 +168,7 @@ func TestImportJSON_AllFalseLockedColors(t *testing.T) {
 	}`
 	os.WriteFile(path, []byte(content), 0644)
 
-	bp, err := ImportJSON(path)
+	bp, err := blueprint.ImportJSON(path)
 	if err != nil {
 		t.Fatalf("ImportJSON failed: %v", err)
 	}
@@ -190,7 +192,7 @@ func TestImportJSON_NullLockedColors(t *testing.T) {
 	}`
 	os.WriteFile(path, []byte(content), 0644)
 
-	bp, err := ImportJSON(path)
+	bp, err := blueprint.ImportJSON(path)
 	if err != nil {
 		t.Fatalf("ImportJSON failed: %v", err)
 	}

--- a/internal/blueprint/service_test.go
+++ b/internal/blueprint/service_test.go
@@ -1,12 +1,14 @@
-package blueprint
+package blueprint_test
 
 import (
+	"aether/internal/blueprint"
+
 	"encoding/json"
 	"testing"
 )
 
 func TestLoadAllJSON(t *testing.T) {
-	svc := NewService()
+	svc := blueprint.NewService()
 	bps, err := svc.LoadAll()
 	if err != nil {
 		t.Fatalf("LoadAll failed: %v", err)
@@ -21,7 +23,7 @@ func TestLoadAllJSON(t *testing.T) {
 	t.Logf("JSON size: %d bytes", len(data))
 
 	// Test round-trip
-	var decoded []Blueprint
+	var decoded []blueprint.Blueprint
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("JSON unmarshal failed: %v", err)
 	}

--- a/internal/omarchy/slug_test.go
+++ b/internal/omarchy/slug_test.go
@@ -1,6 +1,10 @@
-package omarchy
+package omarchy_test
 
-import "testing"
+import (
+	"testing"
+
+	"aether/internal/omarchy"
+)
 
 func TestSlugifyThemeName(t *testing.T) {
 	tests := []struct {
@@ -21,7 +25,7 @@ func TestSlugifyThemeName(t *testing.T) {
 		{"a b c d", "a-b-c-d"},
 	}
 	for _, tt := range tests {
-		got := SlugifyThemeName(tt.in)
+		got := omarchy.SlugifyThemeName(tt.in)
 		if got != tt.want {
 			t.Errorf("SlugifyThemeName(%q) = %q, want %q", tt.in, got, tt.want)
 		}

--- a/internal/omarchy/themes.go
+++ b/internal/omarchy/themes.go
@@ -33,6 +33,8 @@ func SlugifyThemeName(name string) string {
 type Theme struct {
 	Name              string   `json:"name"`
 	Path              string   `json:"path"`
+	Source            string   `json:"source"`
+	ApplyMode         string   `json:"applyMode"`
 	Colors            []string `json:"colors"`
 	Background        string   `json:"background"`
 	Foreground        string   `json:"foreground"`
@@ -46,29 +48,61 @@ type Theme struct {
 // directories to scan for system themes, prepended to the omarchy
 // defaults. Empty entries are ignored.
 const extraThemeDirsEnv = "AETHER_EXTRA_THEME_DIRS"
+const ExtraThemeDirsEnv = extraThemeDirsEnv
+
+const (
+	ThemeSourceExtra         = "extra"
+	ThemeSourceOmarchyConfig = "omarchy-config"
+	ThemeSourceOmarchyData   = "omarchy-data"
+	ThemeSourceGeneric       = "generic"
+	ThemeApplyModeAether     = "aether"
+	ThemeApplyModeOmarchy    = "omarchy"
+	ThemeApplyModeNone       = "none"
+)
+
+type themeSearchDir struct {
+	Path   string
+	Source string
+}
 
 // themeSearchDirs returns the directories where the System Themes tab
 // scans for themes, in precedence order. AETHER_EXTRA_THEME_DIRS comes
 // first (so distro packagers / users can override), then the omarchy
 // defaults, then a generic ~/.config/themes for users on non-omarchy
 // systems who keep their themes in a neutral location.
-func themeSearchDirs() []string {
+func themeSearchEntries() []themeSearchDir {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil
 	}
-	var dirs []string
+	var dirs []themeSearchDir
 	for _, d := range filepath.SplitList(os.Getenv(extraThemeDirsEnv)) {
 		if d != "" {
-			dirs = append(dirs, d)
+			dirs = append(dirs, themeSearchDir{Path: d, Source: ThemeSourceExtra})
 		}
 	}
 	dirs = append(dirs,
-		filepath.Join(home, ".config", "omarchy", "themes"),
-		filepath.Join(home, ".local", "share", "omarchy", "themes"),
-		filepath.Join(home, ".config", "themes"),
+		themeSearchDir{Path: filepath.Join(home, ".config", "omarchy", "themes"), Source: ThemeSourceOmarchyConfig},
+		themeSearchDir{Path: filepath.Join(home, ".local", "share", "omarchy", "themes"), Source: ThemeSourceOmarchyData},
+		themeSearchDir{Path: filepath.Join(home, ".config", "themes"), Source: ThemeSourceGeneric},
 	)
 	return dirs
+}
+
+func themeSearchDirs() []string {
+	entries := themeSearchEntries()
+	if entries == nil {
+		return nil
+	}
+	dirs := make([]string, len(entries))
+	for i, entry := range entries {
+		dirs[i] = entry.Path
+	}
+	return dirs
+}
+
+func ThemeSearchDirs() []string {
+	return themeSearchDirs()
 }
 
 func isImageFile(name string) bool {
@@ -112,8 +146,8 @@ func isGeneratedAetherThemePath(themePath string) bool {
 
 // LoadAllThemes discovers themes from user and system directories.
 func LoadAllThemes() ([]Theme, error) {
-	dirs := themeSearchDirs()
-	if dirs == nil {
+	entries := themeSearchEntries()
+	if entries == nil {
 		return nil, os.ErrNotExist
 	}
 	currentName := GetCurrentThemeName()
@@ -121,14 +155,14 @@ func LoadAllThemes() ([]Theme, error) {
 	seen := make(map[string]bool)
 	var themes []Theme
 
-	for _, dir := range dirs {
-		entries, err := os.ReadDir(dir)
+	for _, searchDir := range entries {
+		entries, err := os.ReadDir(searchDir.Path)
 		if err != nil {
 			continue
 		}
 		for _, entry := range entries {
 			name := entry.Name()
-			themePath := filepath.Join(dir, name)
+			themePath := filepath.Join(searchDir.Path, name)
 
 			if isGeneratedAetherThemePath(themePath) {
 				continue
@@ -146,8 +180,10 @@ func LoadAllThemes() ([]Theme, error) {
 			theme := Theme{
 				Name:           name,
 				Path:           themePath,
+				Source:         searchDir.Source,
+				ApplyMode:      defaultApplyMode(searchDir.Source),
 				IsSymlink:      info.Mode()&os.ModeSymlink != 0,
-				IsCurrentTheme: name == currentName,
+				IsCurrentTheme: isOmarchySource(searchDir.Source) && name == currentName,
 			}
 
 			// ReadDir doesn't always flag symlinks on the DirEntry.
@@ -160,12 +196,13 @@ func LoadAllThemes() ([]Theme, error) {
 				theme.Colors = colors[:]
 				theme.Background = bg
 				theme.Foreground = fg
-				theme.IsAetherGenerated = true
+				theme.ApplyMode = ThemeApplyModeAether
 			} else if data, err := os.ReadFile(filepath.Join(themePath, "kitty.conf")); err == nil {
 				colors, bg, fg := ParseKittyConf(string(data))
 				theme.Colors = colors[:]
 				theme.Background = bg
 				theme.Foreground = fg
+				theme.ApplyMode = ThemeApplyModeAether
 			}
 
 			theme.Wallpapers = listBackgrounds(filepath.Join(themePath, "backgrounds"))
@@ -179,6 +216,17 @@ func LoadAllThemes() ([]Theme, error) {
 	})
 
 	return themes, nil
+}
+
+func isOmarchySource(source string) bool {
+	return source == ThemeSourceOmarchyConfig || source == ThemeSourceOmarchyData
+}
+
+func defaultApplyMode(source string) string {
+	if isOmarchySource(source) {
+		return ThemeApplyModeOmarchy
+	}
+	return ThemeApplyModeNone
 }
 
 // TokyoNightDefaults loads the tokyo-night palette and its first

--- a/internal/omarchy/themes.go
+++ b/internal/omarchy/themes.go
@@ -1,6 +1,8 @@
 package omarchy
 
 import (
+	"aether/internal/platform"
+
 	"os"
 	"path/filepath"
 	"regexp"
@@ -93,6 +95,21 @@ func listBackgrounds(dir string) []string {
 	return paths
 }
 
+func isGeneratedAetherThemePath(themePath string) bool {
+	resolvedThemePath, err := filepath.EvalSymlinks(themePath)
+	if err != nil {
+		return false
+	}
+
+	generatedThemePath := platform.ThemeDir()
+	resolvedGeneratedPath, err := filepath.EvalSymlinks(generatedThemePath)
+	if err != nil {
+		return false
+	}
+
+	return filepath.Clean(resolvedThemePath) == filepath.Clean(resolvedGeneratedPath)
+}
+
 // LoadAllThemes discovers themes from user and system directories.
 func LoadAllThemes() ([]Theme, error) {
 	dirs := themeSearchDirs()
@@ -111,12 +128,16 @@ func LoadAllThemes() ([]Theme, error) {
 		}
 		for _, entry := range entries {
 			name := entry.Name()
+			themePath := filepath.Join(dir, name)
+
+			if isGeneratedAetherThemePath(themePath) {
+				continue
+			}
 			if seen[name] {
 				continue
 			}
 			seen[name] = true
 
-			themePath := filepath.Join(dir, name)
 			info, err := entry.Info()
 			if err != nil {
 				continue

--- a/internal/omarchy/themes_test.go
+++ b/internal/omarchy/themes_test.go
@@ -1,6 +1,8 @@
-package omarchy
+package omarchy_test
 
 import (
+	"aether/internal/omarchy"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,9 +10,9 @@ import (
 )
 
 func TestThemeSearchDirsExtraDirsFirst(t *testing.T) {
-	t.Setenv(extraThemeDirsEnv, "/tmp/aether-test-themes:/opt/themes")
+	t.Setenv(omarchy.ExtraThemeDirsEnv, "/tmp/aether-test-themes:/opt/themes")
 
-	dirs := themeSearchDirs()
+	dirs := omarchy.ThemeSearchDirs()
 	if len(dirs) < 5 {
 		t.Fatalf("expected at least 5 dirs (2 extra + 3 default), got %d: %v", len(dirs), dirs)
 	}
@@ -36,9 +38,9 @@ func TestThemeSearchDirsExtraDirsFirst(t *testing.T) {
 }
 
 func TestThemeSearchDirsEmptyEntries(t *testing.T) {
-	t.Setenv(extraThemeDirsEnv, ":/foo::/bar:")
+	t.Setenv(omarchy.ExtraThemeDirsEnv, ":/foo::/bar:")
 
-	dirs := themeSearchDirs()
+	dirs := omarchy.ThemeSearchDirs()
 	got := strings.Join(dirs, ",")
 	if !strings.Contains(got, "/foo") || !strings.Contains(got, "/bar") {
 		t.Errorf("expected /foo and /bar in dirs, got %v", dirs)
@@ -51,9 +53,9 @@ func TestThemeSearchDirsEmptyEntries(t *testing.T) {
 }
 
 func TestThemeSearchDirsNoEnv(t *testing.T) {
-	t.Setenv(extraThemeDirsEnv, "")
+	t.Setenv(omarchy.ExtraThemeDirsEnv, "")
 
-	dirs := themeSearchDirs()
+	dirs := omarchy.ThemeSearchDirs()
 	if len(dirs) != 3 {
 		t.Errorf("expected 3 default dirs without env, got %d: %v", len(dirs), dirs)
 	}
@@ -64,7 +66,7 @@ func TestLoadAllThemesSkipsGeneratedAetherTheme(t *testing.T) {
 	configDir := filepath.Join(tmp, ".config")
 	t.Setenv("HOME", tmp)
 	t.Setenv("XDG_CONFIG_HOME", configDir)
-	t.Setenv(extraThemeDirsEnv, "")
+	t.Setenv(omarchy.ExtraThemeDirsEnv, "")
 
 	generatedTheme := filepath.Join(configDir, "aether", "theme")
 	if err := os.MkdirAll(filepath.Join(generatedTheme, "backgrounds"), 0755); err != nil {
@@ -96,12 +98,12 @@ func TestLoadAllThemesSkipsGeneratedAetherTheme(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	themes, err := LoadAllThemes()
+	themes, err := omarchy.LoadAllThemes()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var found []Theme
+	var found []omarchy.Theme
 	for _, theme := range themes {
 		if theme.Name == "aether" {
 			found = append(found, theme)
@@ -113,7 +115,48 @@ func TestLoadAllThemesSkipsGeneratedAetherTheme(t *testing.T) {
 	if found[0].Path != genericAether {
 		t.Fatalf("aether theme path = %q, want %q", found[0].Path, genericAether)
 	}
+	if found[0].Source != omarchy.ThemeSourceGeneric {
+		t.Fatalf("aether theme source = %q, want %q", found[0].Source, omarchy.ThemeSourceGeneric)
+	}
+	if found[0].ApplyMode != omarchy.ThemeApplyModeAether {
+		t.Fatalf("aether apply mode = %q, want %q", found[0].ApplyMode, omarchy.ThemeApplyModeAether)
+	}
 	if len(found[0].Wallpapers) != 1 || !strings.HasSuffix(found[0].Wallpapers[0], "aether.png") {
 		t.Fatalf("aether wallpapers = %#v, want generic wallpaper", found[0].Wallpapers)
+	}
+}
+
+func TestLoadAllThemesMarksCurrentOnlyForOmarchySource(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, ".config")
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv(omarchy.ExtraThemeDirsEnv, "")
+
+	currentDir := filepath.Join(configDir, "omarchy", "current")
+	if err := os.MkdirAll(currentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(currentDir, "theme.name"), []byte("aura\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	genericAura := filepath.Join(configDir, "themes", "aura")
+	if err := os.MkdirAll(genericAura, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(genericAura, "colors.toml"), []byte("background = '#111111'\nforeground = '#eeeeee'\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	themes, err := omarchy.LoadAllThemes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(themes) != 1 {
+		t.Fatalf("expected one theme, got %d: %#v", len(themes), themes)
+	}
+	if themes[0].IsCurrentTheme {
+		t.Fatalf("generic theme was marked current: %#v", themes[0])
 	}
 }

--- a/internal/omarchy/themes_test.go
+++ b/internal/omarchy/themes_test.go
@@ -58,3 +58,62 @@ func TestThemeSearchDirsNoEnv(t *testing.T) {
 		t.Errorf("expected 3 default dirs without env, got %d: %v", len(dirs), dirs)
 	}
 }
+
+func TestLoadAllThemesSkipsGeneratedAetherTheme(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, ".config")
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv(extraThemeDirsEnv, "")
+
+	generatedTheme := filepath.Join(configDir, "aether", "theme")
+	if err := os.MkdirAll(filepath.Join(generatedTheme, "backgrounds"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(generatedTheme, "colors.toml"), []byte("background = '#000000'\nforeground = '#ffffff'\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(generatedTheme, "backgrounds", "0-preview.jpg"), []byte("generated"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	omarchyThemes := filepath.Join(configDir, "omarchy", "themes")
+	if err := os.MkdirAll(omarchyThemes, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(generatedTheme, filepath.Join(omarchyThemes, "aether")); err != nil {
+		t.Fatal(err)
+	}
+
+	genericAether := filepath.Join(configDir, "themes", "aether")
+	if err := os.MkdirAll(filepath.Join(genericAether, "backgrounds"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(genericAether, "colors.toml"), []byte("background = '#111111'\nforeground = '#eeeeee'\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(genericAether, "backgrounds", "aether.png"), []byte("generic"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	themes, err := LoadAllThemes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found []Theme
+	for _, theme := range themes {
+		if theme.Name == "aether" {
+			found = append(found, theme)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected one aether theme, got %d: %#v", len(found), found)
+	}
+	if found[0].Path != genericAether {
+		t.Fatalf("aether theme path = %q, want %q", found[0].Path, genericAether)
+	}
+	if len(found[0].Wallpapers) != 1 || !strings.HasSuffix(found[0].Wallpapers[0], "aether.png") {
+		t.Fatalf("aether wallpapers = %#v, want generic wallpaper", found[0].Wallpapers)
+	}
+}

--- a/internal/omarchy/toml_test.go
+++ b/internal/omarchy/toml_test.go
@@ -1,7 +1,9 @@
-package omarchy
+package omarchy_test
 
 import (
 	"testing"
+
+	"aether/internal/omarchy"
 )
 
 func TestParseColorsToml(t *testing.T) {
@@ -37,7 +39,7 @@ color13 = "#bb9af7"
 color14 = "#7dcfff"
 color15 = "#c0caf5"
 `
-	colors, bg, fg := ParseColorsToml(sample)
+	colors, bg, fg := omarchy.ParseColorsToml(sample)
 
 	if bg != "#1a1b26" {
 		t.Errorf("bg = %q, want #1a1b26", bg)

--- a/internal/platform/exec.go
+++ b/internal/platform/exec.go
@@ -29,6 +29,13 @@ func RunSync(name string, args ...string) (string, error) {
 // RunAsync starts a command detached in the background and returns immediately.
 // LD_PRELOAD is stripped from the environment to prevent layer-shell conflicts.
 func RunAsync(name string, args ...string) error {
+	_, err := StartDetached(name, args...)
+	return err
+}
+
+// StartDetached starts a command detached in the background and returns its PID.
+// LD_PRELOAD is stripped from the environment to prevent layer-shell conflicts.
+func StartDetached(name string, args ...string) (int, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Env = filteredEnv()
 
@@ -37,7 +44,10 @@ func RunAsync(name string, args ...string) error {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 
-	return cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	return cmd.Process.Pid, nil
 }
 
 // IsNvidiaWayland returns true if running on Wayland with an NVIDIA GPU.

--- a/internal/platform/fileutil.go
+++ b/internal/platform/fileutil.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -123,6 +124,28 @@ func CreateSymlink(target, link string) error {
 	}
 	// Remove existing link (or file) if present; ignore error if it doesn't exist.
 	_ = os.Remove(link)
+	return os.Symlink(target, link)
+}
+
+// ReplaceSymlink creates link -> target. If link already exists, it is only
+// replaced when the existing path is itself a symlink. Real files and
+// directories are left untouched so integrations cannot delete user-owned
+// config by accident.
+func ReplaceSymlink(target, link string) error {
+	if err := EnsureDir(filepath.Dir(link)); err != nil {
+		return err
+	}
+	info, err := os.Lstat(link)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("refusing to replace non-symlink path: %s", link)
+		}
+		if err := os.Remove(link); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
 	return os.Symlink(target, link)
 }
 

--- a/internal/platform/fileutil_test.go
+++ b/internal/platform/fileutil_test.go
@@ -1,0 +1,53 @@
+package platform_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"aether/internal/platform"
+)
+
+func TestReplaceSymlinkReplacesOnlySymlinks(t *testing.T) {
+	dir := t.TempDir()
+	firstTarget := filepath.Join(dir, "first")
+	secondTarget := filepath.Join(dir, "second")
+	link := filepath.Join(dir, "link")
+
+	if err := os.WriteFile(firstTarget, []byte("first"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secondTarget, []byte("second"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := platform.ReplaceSymlink(firstTarget, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := platform.ReplaceSymlink(secondTarget, link); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.Readlink(link); err != nil || got != secondTarget {
+		t.Fatalf("link = %q, %v; want %q", got, err, secondTarget)
+	}
+}
+
+func TestReplaceSymlinkRefusesRealPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "real-file")
+
+	if err := os.WriteFile(target, []byte("target"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(link, []byte("user config"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := platform.ReplaceSymlink(target, link); err == nil {
+		t.Fatal("expected error for non-symlink path")
+	}
+	if data, err := os.ReadFile(link); err != nil || string(data) != "user config" {
+		t.Fatalf("real path changed: %q, %v", string(data), err)
+	}
+}

--- a/internal/template/custom_apps.go
+++ b/internal/template/custom_apps.go
@@ -103,11 +103,11 @@ func processCustomApp(appPath, appName, themeDir string, variables map[string]st
 
 	// Create destination symlink if configured
 	if config.Destination != "" {
-		destPath := expandHome(config.Destination)
+		destPath := ExpandHome(config.Destination)
 		if err := platform.EnsureDir(filepath.Dir(destPath)); err != nil {
 			return err
 		}
-		if err := platform.CreateSymlink(outputPath, destPath); err != nil {
+		if err := platform.ReplaceSymlink(outputPath, destPath); err != nil {
 			log.Printf("[%s] Error creating symlink to %s: %v", appName, destPath, err)
 		} else {
 			log.Printf("[%s] Symlinked -> %s", appName, destPath)
@@ -144,8 +144,8 @@ func ReadCustomOverride(fileName string) (string, bool) {
 	return content, true
 }
 
-// expandHome replaces a leading "~/" with the user's home directory.
-func expandHome(path string) string {
+// ExpandHome replaces a leading "~/" with the user's home directory.
+func ExpandHome(path string) string {
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/internal/template/custom_apps_test.go
+++ b/internal/template/custom_apps_test.go
@@ -1,12 +1,19 @@
-package template
+package template_test
 
 import (
+	"aether/internal/template"
+
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type customAppConfig struct {
+	Template    string `json:"template"`
+	Destination string `json:"destination"`
+}
 
 func TestProcessCustomApps_NoDir(t *testing.T) {
 	themeDir := t.TempDir()
@@ -21,7 +28,7 @@ func TestProcessCustomApps_NoDir(t *testing.T) {
 		}
 	}()
 
-	err := ProcessCustomApps(themeDir, map[string]string{"background": "#1e1e2e"})
+	err := template.ProcessCustomApps(themeDir, map[string]string{"background": "#1e1e2e"})
 	if err != nil {
 		t.Fatalf("expected nil error for missing custom dir, got: %v", err)
 	}
@@ -36,7 +43,7 @@ func TestProcessCustomApps_EmptyDir(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
 	themeDir := t.TempDir()
-	err := ProcessCustomApps(themeDir, map[string]string{"background": "#1e1e2e"})
+	err := template.ProcessCustomApps(themeDir, map[string]string{"background": "#1e1e2e"})
 	if err != nil {
 		t.Fatalf("expected nil error for empty custom dir, got: %v", err)
 	}
@@ -55,7 +62,7 @@ func TestProcessCustomApps_SkipsFiles(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
 	themeDir := t.TempDir()
-	err := ProcessCustomApps(themeDir, map[string]string{})
+	err := template.ProcessCustomApps(themeDir, map[string]string{})
 	if err != nil {
 		t.Fatalf("expected nil error when skipping non-dir entries, got: %v", err)
 	}
@@ -101,7 +108,7 @@ rgba = {blue.rgba:0.7}
 		"blue":       "#89b4fa",
 	}
 
-	err := ProcessCustomApps(themeDir, variables)
+	err := template.ProcessCustomApps(themeDir, variables)
 	if err != nil {
 		t.Fatalf("ProcessCustomApps failed: %v", err)
 	}
@@ -143,7 +150,7 @@ func TestProcessCustomApps_MissingConfigJSON(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
 	themeDir := t.TempDir()
-	err := ProcessCustomApps(themeDir, map[string]string{})
+	err := template.ProcessCustomApps(themeDir, map[string]string{})
 	if err != nil {
 		t.Fatalf("expected nil error for missing config.json, got: %v", err)
 	}
@@ -165,7 +172,7 @@ func TestProcessCustomApps_EmptyTemplateField(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
 	themeDir := t.TempDir()
-	err := ProcessCustomApps(themeDir, map[string]string{})
+	err := template.ProcessCustomApps(themeDir, map[string]string{})
 	if err != nil {
 		t.Fatalf("expected nil error for empty template field, got: %v", err)
 	}
@@ -187,7 +194,7 @@ func TestProcessCustomApps_MissingTemplateFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
 	themeDir := t.TempDir()
-	err := ProcessCustomApps(themeDir, map[string]string{})
+	err := template.ProcessCustomApps(themeDir, map[string]string{})
 	if err != nil {
 		t.Fatalf("expected nil error for missing template file, got: %v", err)
 	}
@@ -212,7 +219,7 @@ func TestProcessCustomApps_NoDestination(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
 	themeDir := t.TempDir()
-	err := ProcessCustomApps(themeDir, map[string]string{"background": "#000000"})
+	err := template.ProcessCustomApps(themeDir, map[string]string{"background": "#000000"})
 	if err != nil {
 		t.Fatalf("expected nil error with no destination, got: %v", err)
 	}
@@ -246,7 +253,7 @@ func TestProcessCustomApps_MultipleApps(t *testing.T) {
 	}
 
 	themeDir := t.TempDir()
-	err := ProcessCustomApps(themeDir, map[string]string{"foreground": "#ffffff"})
+	err := template.ProcessCustomApps(themeDir, map[string]string{"foreground": "#ffffff"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -278,7 +285,7 @@ func TestReadCustomOverride_Found(t *testing.T) {
 	}
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
-	content, found := ReadCustomOverride("kitty.conf")
+	content, found := template.ReadCustomOverride("kitty.conf")
 	if !found {
 		t.Fatal("expected override to be found")
 	}
@@ -295,7 +302,7 @@ func TestReadCustomOverride_NotFound(t *testing.T) {
 	}
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
-	_, found := ReadCustomOverride("nonexistent.conf")
+	_, found := template.ReadCustomOverride("nonexistent.conf")
 	if found {
 		t.Fatal("expected override NOT to be found")
 	}
@@ -310,7 +317,7 @@ func TestReadCustomOverride_IgnoresDirectories(t *testing.T) {
 	}
 	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
 
-	_, found := ReadCustomOverride("kitty.conf")
+	_, found := template.ReadCustomOverride("kitty.conf")
 	if found {
 		t.Fatal("expected directory to NOT be treated as an override")
 	}
@@ -319,7 +326,7 @@ func TestReadCustomOverride_IgnoresDirectories(t *testing.T) {
 func TestReadCustomOverride_CustomDirMissing(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "nonexistent"))
 
-	_, found := ReadCustomOverride("kitty.conf")
+	_, found := template.ReadCustomOverride("kitty.conf")
 	if found {
 		t.Fatal("expected false when custom dir doesn't exist")
 	}
@@ -345,9 +352,9 @@ func TestExpandHome(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := expandHome(tt.in)
+			got := template.ExpandHome(tt.in)
 			if got != tt.want {
-				t.Errorf("expandHome(%q) = %q, want %q", tt.in, got, tt.want)
+				t.Errorf("template.ExpandHome(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -1,6 +1,8 @@
-package template
+package template_test
 
 import (
+	"aether/internal/template"
+
 	"sort"
 	"strings"
 	"testing"
@@ -66,17 +68,17 @@ func TestExtractVariableNames(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExtractVariableNames(tt.input)
+			got := template.ExtractVariableNames(tt.input)
 			sort.Strings(got)
 			sort.Strings(tt.want)
 
 			if len(got) != len(tt.want) {
-				t.Errorf("ExtractVariableNames() = %v, want %v", got, tt.want)
+				t.Errorf("template.ExtractVariableNames() = %v, want %v", got, tt.want)
 				return
 			}
 			for i := range got {
 				if got[i] != tt.want[i] {
-					t.Errorf("ExtractVariableNames() = %v, want %v", got, tt.want)
+					t.Errorf("template.ExtractVariableNames() = %v, want %v", got, tt.want)
 					return
 				}
 			}
@@ -215,9 +217,9 @@ func TestReplaceVariable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ReplaceVariable(tt.content, tt.key, tt.value)
+			got := template.ReplaceVariable(tt.content, tt.key, tt.value)
 			if got != tt.want {
-				t.Errorf("ReplaceVariable() = %q, want %q", got, tt.want)
+				t.Errorf("template.ReplaceVariable() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -298,16 +300,16 @@ func TestProcessTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ProcessTemplate(tt.content, tt.variables)
+			got := template.ProcessTemplate(tt.content, tt.variables)
 			if got != tt.want {
-				t.Errorf("ProcessTemplate() =\n%s\nwant:\n%s", got, tt.want)
+				t.Errorf("template.ProcessTemplate() =\n%s\nwant:\n%s", got, tt.want)
 			}
 		})
 	}
 }
 
 func TestBuildVariables(t *testing.T) {
-	roles := ColorRoles{
+	roles := template.ColorRoles{
 		Background:          "#1e1e2e",
 		Foreground:          "#cdd6f4",
 		Black:               "#45475a",
@@ -333,7 +335,7 @@ func TestBuildVariables(t *testing.T) {
 	}
 
 	t.Run("dark mode", func(t *testing.T) {
-		vars := BuildVariables(roles, false)
+		vars := template.BuildVariables(roles, false)
 
 		// Check base colors
 		if vars["background"] != "#1e1e2e" {
@@ -376,19 +378,19 @@ func TestBuildVariables(t *testing.T) {
 	})
 
 	t.Run("light mode", func(t *testing.T) {
-		vars := BuildVariables(roles, true)
+		vars := template.BuildVariables(roles, true)
 		if vars["theme_type"] != "light" {
 			t.Errorf("theme_type = %s, want light", vars["theme_type"])
 		}
 	})
 
 	t.Run("defaults for empty extended colors", func(t *testing.T) {
-		emptyRoles := ColorRoles{
+		emptyRoles := template.ColorRoles{
 			Background: "#1e1e2e",
 			Foreground: "#cdd6f4",
 			Blue:       "#89b4fa",
 		}
-		vars := BuildVariables(emptyRoles, false)
+		vars := template.BuildVariables(emptyRoles, false)
 
 		if vars["accent"] != "#89b4fa" {
 			t.Errorf("accent = %s, want #89b4fa (default to blue)", vars["accent"])
@@ -428,7 +430,7 @@ func TestRecomputeDerived(t *testing.T) {
 		merged["background"] = "#ff0000" // override
 		overrides := map[string]string{"background": "#ff0000"}
 
-		RecomputeDerived(merged, overrides)
+		template.RecomputeDerived(merged, overrides)
 
 		if merged["bg"] != "#ff0000" {
 			t.Errorf("bg = %s, want #ff0000", merged["bg"])
@@ -453,7 +455,7 @@ func TestRecomputeDerived(t *testing.T) {
 			"dark_bg":    "#00ff00",
 		}
 
-		RecomputeDerived(merged, overrides)
+		template.RecomputeDerived(merged, overrides)
 
 		// dark_bg was explicitly overridden, should NOT be recomputed
 		if merged["dark_bg"] != "#00ff00" {

--- a/internal/theme/applier.go
+++ b/internal/theme/applier.go
@@ -52,6 +52,47 @@ func IsOmarchyInstalled() bool {
 	return err == nil
 }
 
+const (
+	WallpaperBackendAuto    = "auto"
+	WallpaperBackendOmarchy = "omarchy"
+	WallpaperBackendAwww    = "awww"
+	WallpaperBackendNone    = "none"
+)
+
+type wallpaperBackendAvailability struct {
+	Omarchy bool
+	Awww    bool
+}
+
+func normalizeWallpaperBackend(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", WallpaperBackendAuto:
+		return WallpaperBackendAuto
+	case WallpaperBackendOmarchy:
+		return WallpaperBackendOmarchy
+	case WallpaperBackendAwww:
+		return WallpaperBackendAwww
+	case WallpaperBackendNone:
+		return WallpaperBackendNone
+	default:
+		return WallpaperBackendAuto
+	}
+}
+
+func selectWallpaperBackend(requested string, availability wallpaperBackendAvailability) string {
+	backend := normalizeWallpaperBackend(requested)
+	if backend != WallpaperBackendAuto {
+		return backend
+	}
+	if availability.Omarchy {
+		return WallpaperBackendOmarchy
+	}
+	if availability.Awww {
+		return WallpaperBackendAwww
+	}
+	return WallpaperBackendNone
+}
+
 // HandleLightModeMarker creates or removes the light.mode marker file in
 // the theme directory. The presence of this file signals light mode to
 // consumers.
@@ -169,6 +210,18 @@ func IsAetherWpAvailable() bool {
 	return runtime.GOOS == "linux" && aetherWpPath() != ""
 }
 
+// IsAwwwAvailable returns true when awww is installed and its daemon responds.
+func IsAwwwAvailable() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if _, err := exec.LookPath("awww"); err != nil {
+		return false
+	}
+	_, err := platform.RunSync("awww", "query")
+	return err == nil
+}
+
 // stopAetherWp stops any running aether-wp instance using its --stop flag.
 // Runs synchronously so the old instance is fully gone before a new one starts.
 func stopAetherWp() {
@@ -219,13 +272,22 @@ func applyWallpaperSwaybg(symlinkPath string) error {
 	return nil
 }
 
-// ApplyWallpaper creates the background symlink at
-// ~/.config/omarchy/current/background pointing to wallpaperPath, then
-// uses aether-wp for animated files (.gif, .mp4, .webm) or swaybg for
-// static images. Only runs on Linux Omarchy systems.
-func ApplyWallpaper(wallpaperPath string, settings Settings) error {
-	if runtime.GOOS != "linux" || wallpaperPath == "" || !IsOmarchyInstalled() {
-		return nil
+func applyWallpaperAwww(wallpaperPath string) error {
+	if _, err := exec.LookPath("awww"); err != nil {
+		return fmt.Errorf("awww binary not found")
+	}
+	_ = platform.RunAsync("pkill", "-x", "swaybg")
+	stopAetherWp()
+	if _, err := platform.RunSync("awww", "img", wallpaperPath); err != nil {
+		return fmt.Errorf("failed to set wallpaper with awww: %w", err)
+	}
+	log.Printf("Set wallpaper with awww: %s", wallpaperPath)
+	return nil
+}
+
+func applyWallpaperOmarchy(wallpaperPath string, settings Settings) error {
+	if !IsOmarchyInstalled() {
+		return fmt.Errorf("omarchy-theme-set not found")
 	}
 
 	home, err := os.UserHomeDir()
@@ -247,6 +309,32 @@ func ApplyWallpaper(wallpaperPath string, settings Settings) error {
 		return applyWallpaperAetherWp(wallpaperPath, settings.VideoCpuMode)
 	}
 	return applyWallpaperSwaybg(symlinkPath)
+}
+
+// ApplyWallpaper sets wallpaperPath using Aether's configured wallpaper backend.
+// Auto keeps Omarchy behavior when available and uses awww on standalone Wayland
+// sessions where its daemon is already running.
+func ApplyWallpaper(wallpaperPath string, settings Settings) error {
+	if runtime.GOOS != "linux" || wallpaperPath == "" {
+		return nil
+	}
+
+	backend := selectWallpaperBackend(settings.WallpaperBackend, wallpaperBackendAvailability{
+		Omarchy: IsOmarchyInstalled(),
+		Awww:    IsAwwwAvailable(),
+	})
+
+	switch backend {
+	case WallpaperBackendOmarchy:
+		return applyWallpaperOmarchy(wallpaperPath, settings)
+	case WallpaperBackendAwww:
+		return applyWallpaperAwww(wallpaperPath)
+	case WallpaperBackendNone:
+		log.Println("Wallpaper application skipped")
+		return nil
+	default:
+		return nil
+	}
 }
 
 // ClearTheme removes GTK CSS files, the theme override symlink and CSS,

--- a/internal/theme/applier.go
+++ b/internal/theme/applier.go
@@ -1,13 +1,16 @@
 package theme
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"syscall"
 
 	"aether/internal/platform"
 )
@@ -48,7 +51,7 @@ func IsOmarchyInstalled() bool {
 	if runtime.GOOS != "linux" {
 		return false
 	}
-	_, err := platform.RunSync("which", "omarchy-theme-set")
+	_, err := exec.LookPath("omarchy-theme-set")
 	return err == nil
 }
 
@@ -56,12 +59,14 @@ const (
 	WallpaperBackendAuto    = "auto"
 	WallpaperBackendOmarchy = "omarchy"
 	WallpaperBackendAwww    = "awww"
+	WallpaperBackendSwaybg  = "swaybg"
 	WallpaperBackendNone    = "none"
 )
 
-type wallpaperBackendAvailability struct {
+type WallpaperBackendAvailability struct {
 	Omarchy bool
 	Awww    bool
+	Swaybg  bool
 }
 
 func normalizeWallpaperBackend(value string) string {
@@ -72,6 +77,8 @@ func normalizeWallpaperBackend(value string) string {
 		return WallpaperBackendOmarchy
 	case WallpaperBackendAwww:
 		return WallpaperBackendAwww
+	case WallpaperBackendSwaybg:
+		return WallpaperBackendSwaybg
 	case WallpaperBackendNone:
 		return WallpaperBackendNone
 	default:
@@ -79,7 +86,11 @@ func normalizeWallpaperBackend(value string) string {
 	}
 }
 
-func selectWallpaperBackend(requested string, availability wallpaperBackendAvailability) string {
+func NormalizeWallpaperBackend(value string) string {
+	return normalizeWallpaperBackend(value)
+}
+
+func selectWallpaperBackend(requested string, availability WallpaperBackendAvailability) string {
 	backend := normalizeWallpaperBackend(requested)
 	if backend != WallpaperBackendAuto {
 		return backend
@@ -90,7 +101,14 @@ func selectWallpaperBackend(requested string, availability wallpaperBackendAvail
 	if availability.Awww {
 		return WallpaperBackendAwww
 	}
+	if availability.Swaybg {
+		return WallpaperBackendSwaybg
+	}
 	return WallpaperBackendNone
+}
+
+func SelectWallpaperBackend(requested string, availability WallpaperBackendAvailability) string {
+	return selectWallpaperBackend(requested, availability)
 }
 
 // HandleLightModeMarker creates or removes the light.mode marker file in
@@ -125,29 +143,8 @@ func HandleLightModeMarker(themeDir string, lightMode bool) error {
 
 // CreateOmarchySymlink creates a symlink from
 // ~/.config/omarchy/themes/aether -> themeDir.
-// If the target already exists as a regular directory (not a symlink), it is
-// removed first.
 func CreateOmarchySymlink(themeDir string) error {
-	omarchyDir := platform.OmarchyThemeDir()
-	parentDir := filepath.Dir(omarchyDir)
-
-	if err := platform.EnsureDir(parentDir); err != nil {
-		return err
-	}
-
-	// Check if the path exists and is not a symlink
-	info, err := os.Lstat(omarchyDir)
-	if err == nil {
-		if info.Mode()&os.ModeSymlink == 0 && info.IsDir() {
-			// It's a real directory, remove it
-			if err := os.RemoveAll(omarchyDir); err != nil {
-				return err
-			}
-			log.Println("Removed existing omarchy theme directory")
-		}
-	}
-
-	return platform.CreateSymlink(themeDir, omarchyDir)
+	return platform.ReplaceSymlink(themeDir, platform.OmarchyThemeDir())
 }
 
 // animatedExtensions are file types handled by aether-wp instead of swaybg.
@@ -222,6 +219,92 @@ func IsAwwwAvailable() bool {
 	return err == nil
 }
 
+// IsSwaybgAvailable returns true when swaybg can be launched for static
+// wallpapers.
+func IsSwaybgAvailable() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	_, err := exec.LookPath("swaybg")
+	return err == nil
+}
+
+func swaybgPIDPath() string {
+	return filepath.Join(platform.CacheDir(), "swaybg.pid")
+}
+
+type swaybgState struct {
+	PID       int    `json:"pid"`
+	Wallpaper string `json:"wallpaper"`
+}
+
+func recordSwaybgPID(pid int, wallpaperPath string) {
+	if err := platform.EnsureDir(platform.CacheDir()); err != nil {
+		log.Printf("Warning: could not create cache dir for swaybg PID: %v", err)
+		return
+	}
+	data, err := json.Marshal(swaybgState{PID: pid, Wallpaper: wallpaperPath})
+	if err != nil {
+		log.Printf("Warning: could not encode swaybg PID: %v", err)
+		return
+	}
+	if err := os.WriteFile(swaybgPIDPath(), append(data, '\n'), 0644); err != nil {
+		log.Printf("Warning: could not write swaybg PID: %v", err)
+	}
+}
+
+func processComm(pid int) string {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "comm"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func processCmdline(pid int) string {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return ""
+	}
+	return strings.ReplaceAll(string(data), "\x00", " ")
+}
+
+func stopAetherSwaybg() {
+	data, err := os.ReadFile(swaybgPIDPath())
+	if err != nil {
+		return
+	}
+	_ = os.Remove(swaybgPIDPath())
+
+	var state swaybgState
+	if err := json.Unmarshal(data, &state); err != nil {
+		pid, convErr := strconv.Atoi(strings.TrimSpace(string(data)))
+		if convErr != nil {
+			return
+		}
+		state.PID = pid
+	}
+	if state.PID <= 0 {
+		return
+	}
+	switch processComm(state.PID) {
+	case "swaybg", "uwsm-app":
+	default:
+		return
+	}
+	if state.Wallpaper != "" && !strings.Contains(processCmdline(state.PID), state.Wallpaper) {
+		return
+	}
+
+	process, err := os.FindProcess(state.PID)
+	if err != nil {
+		return
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		log.Printf("Warning: could not stop Aether swaybg process %d: %v", state.PID, err)
+	}
+}
+
 // stopAetherWp stops any running aether-wp instance using its --stop flag.
 // Runs synchronously so the old instance is fully gone before a new one starts.
 func stopAetherWp() {
@@ -240,7 +323,7 @@ func applyWallpaperAetherWp(mediaPath string, cpuMode bool) error {
 		return fmt.Errorf("aether-wp binary not found")
 	}
 
-	_ = platform.RunAsync("pkill", "-x", "swaybg")
+	stopAetherSwaybg()
 	stopAetherWp()
 
 	args := []string{wpBin}
@@ -260,14 +343,29 @@ func applyWallpaperAetherWp(mediaPath string, cpuMode bool) error {
 	return nil
 }
 
-// applyWallpaperSwaybg sets the wallpaper using swaybg (static images).
-func applyWallpaperSwaybg(symlinkPath string) error {
-	_ = platform.RunAsync("pkill", "-x", "swaybg")
+// applyWallpaperSwaybg sets the wallpaper using swaybg for static images.
+func applyWallpaperSwaybg(wallpaperPath string, preferUwsm bool) error {
+	if !IsSwaybgAvailable() {
+		return fmt.Errorf("swaybg binary not found")
+	}
+	stopAetherSwaybg()
 	stopAetherWp()
-	if err := platform.RunAsync("setsid", "uwsm-app", "--", "swaybg", "-i", symlinkPath, "-m", "fill"); err != nil {
+
+	name := "swaybg"
+	args := []string{"-i", wallpaperPath, "-m", "fill"}
+	if preferUwsm {
+		if _, err := exec.LookPath("uwsm-app"); err == nil {
+			name = "uwsm-app"
+			args = []string{"--", "swaybg", "-i", wallpaperPath, "-m", "fill"}
+		}
+	}
+
+	pid, err := platform.StartDetached(name, args...)
+	if err != nil {
 		log.Printf("Warning: could not restart swaybg: %v", err)
 		return err
 	}
+	recordSwaybgPID(pid, wallpaperPath)
 	log.Println("Swaybg restarted successfully")
 	return nil
 }
@@ -276,7 +374,7 @@ func applyWallpaperAwww(wallpaperPath string) error {
 	if _, err := exec.LookPath("awww"); err != nil {
 		return fmt.Errorf("awww binary not found")
 	}
-	_ = platform.RunAsync("pkill", "-x", "swaybg")
+	stopAetherSwaybg()
 	stopAetherWp()
 	if _, err := platform.RunSync("awww", "img", wallpaperPath); err != nil {
 		return fmt.Errorf("failed to set wallpaper with awww: %w", err)
@@ -300,7 +398,7 @@ func applyWallpaperOmarchy(wallpaperPath string, settings Settings) error {
 		return err
 	}
 
-	if err := platform.CreateSymlink(wallpaperPath, symlinkPath); err != nil {
+	if err := platform.ReplaceSymlink(wallpaperPath, symlinkPath); err != nil {
 		return err
 	}
 	log.Printf("Created wallpaper symlink: %s -> %s", symlinkPath, wallpaperPath)
@@ -308,20 +406,20 @@ func applyWallpaperOmarchy(wallpaperPath string, settings Settings) error {
 	if IsAnimatedWallpaper(wallpaperPath) && IsAetherWpAvailable() {
 		return applyWallpaperAetherWp(wallpaperPath, settings.VideoCpuMode)
 	}
-	return applyWallpaperSwaybg(symlinkPath)
+	return applyWallpaperSwaybg(symlinkPath, true)
 }
 
 // ApplyWallpaper sets wallpaperPath using Aether's configured wallpaper backend.
-// Auto keeps Omarchy behavior when available and uses awww on standalone Wayland
-// sessions where its daemon is already running.
+// Auto keeps Omarchy behavior when available, then tries awww, then swaybg.
 func ApplyWallpaper(wallpaperPath string, settings Settings) error {
 	if runtime.GOOS != "linux" || wallpaperPath == "" {
 		return nil
 	}
 
-	backend := selectWallpaperBackend(settings.WallpaperBackend, wallpaperBackendAvailability{
+	backend := selectWallpaperBackend(settings.WallpaperBackend, WallpaperBackendAvailability{
 		Omarchy: IsOmarchyInstalled(),
 		Awww:    IsAwwwAvailable(),
+		Swaybg:  IsSwaybgAvailable(),
 	})
 
 	switch backend {
@@ -329,6 +427,11 @@ func ApplyWallpaper(wallpaperPath string, settings Settings) error {
 		return applyWallpaperOmarchy(wallpaperPath, settings)
 	case WallpaperBackendAwww:
 		return applyWallpaperAwww(wallpaperPath)
+	case WallpaperBackendSwaybg:
+		if IsAnimatedWallpaper(wallpaperPath) && IsAetherWpAvailable() {
+			return applyWallpaperAetherWp(wallpaperPath, settings.VideoCpuMode)
+		}
+		return applyWallpaperSwaybg(wallpaperPath, false)
 	case WallpaperBackendNone:
 		log.Println("Wallpaper application skipped")
 		return nil
@@ -342,6 +445,7 @@ func ApplyWallpaper(wallpaperPath string, settings Settings) error {
 func ClearTheme() error {
 	// Stop any running animated wallpaper
 	stopAetherWp()
+	stopAetherSwaybg()
 
 	// Delete Aether override CSS file in theme dir (cross-platform)
 	overrideCss := filepath.Join(platform.ThemeDir(), "aether.override.css")
@@ -377,15 +481,16 @@ func ClearTheme() error {
 		log.Printf("Warning: could not delete theme override symlink: %v", err)
 	}
 
-	// Switch to tokyo-night theme
-	if err := platform.RunAsync("omarchy-theme-set", "tokyo-night"); err != nil {
-		log.Printf("Warning: could not switch to tokyo-night: %v", err)
-	} else {
-		log.Println("Cleared Aether theme and switched to tokyo-night")
-	}
+	if IsOmarchyInstalled() {
+		if err := platform.RunAsync("omarchy-theme-set", "tokyo-night"); err != nil {
+			log.Printf("Warning: could not switch to tokyo-night: %v", err)
+		} else {
+			log.Println("Cleared Aether theme and switched to tokyo-night")
+		}
 
-	// Restart xdg-desktop-portal-gtk (best-effort)
-	_ = platform.RunAsync("killall", "xdg-desktop-portal-gtk")
+		// Restart xdg-desktop-portal-gtk (best-effort)
+		_ = platform.RunAsync("killall", "xdg-desktop-portal-gtk")
+	}
 
 	return nil
 }

--- a/internal/theme/applier_test.go
+++ b/internal/theme/applier_test.go
@@ -1,0 +1,100 @@
+package theme
+
+import "testing"
+
+func TestNormalizeWallpaperBackend(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty defaults to auto", in: "", want: WallpaperBackendAuto},
+		{name: "auto", in: "auto", want: WallpaperBackendAuto},
+		{name: "omarchy", in: "omarchy", want: WallpaperBackendOmarchy},
+		{name: "awww", in: "awww", want: WallpaperBackendAwww},
+		{name: "none", in: "none", want: WallpaperBackendNone},
+		{name: "case and space", in: " AWWW ", want: WallpaperBackendAwww},
+		{name: "unknown defaults to auto", in: "custom", want: WallpaperBackendAuto},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeWallpaperBackend(tt.in); got != tt.want {
+				t.Fatalf("normalizeWallpaperBackend(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectWallpaperBackend(t *testing.T) {
+	tests := []struct {
+		name         string
+		requested    string
+		availability wallpaperBackendAvailability
+		want         string
+	}{
+		{
+			name:      "auto prefers omarchy",
+			requested: WallpaperBackendAuto,
+			availability: wallpaperBackendAvailability{
+				Omarchy: true,
+				Awww:    true,
+			},
+			want: WallpaperBackendOmarchy,
+		},
+		{
+			name:      "auto falls back to awww",
+			requested: WallpaperBackendAuto,
+			availability: wallpaperBackendAvailability{
+				Awww: true,
+			},
+			want: WallpaperBackendAwww,
+		},
+		{
+			name:      "auto skips when unavailable",
+			requested: WallpaperBackendAuto,
+			want:      WallpaperBackendNone,
+		},
+		{
+			name:      "explicit awww wins",
+			requested: WallpaperBackendAwww,
+			availability: wallpaperBackendAvailability{
+				Omarchy: true,
+			},
+			want: WallpaperBackendAwww,
+		},
+		{
+			name:      "explicit omarchy wins",
+			requested: WallpaperBackendOmarchy,
+			availability: wallpaperBackendAvailability{
+				Awww: true,
+			},
+			want: WallpaperBackendOmarchy,
+		},
+		{
+			name:      "explicit none wins",
+			requested: WallpaperBackendNone,
+			availability: wallpaperBackendAvailability{
+				Omarchy: true,
+				Awww:    true,
+			},
+			want: WallpaperBackendNone,
+		},
+		{
+			name:      "unknown uses auto",
+			requested: "other",
+			availability: wallpaperBackendAvailability{
+				Awww: true,
+			},
+			want: WallpaperBackendAwww,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectWallpaperBackend(tt.requested, tt.availability); got != tt.want {
+				t.Fatalf("selectWallpaperBackend(%q, %+v) = %q, want %q", tt.requested, tt.availability, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/theme/applier_test.go
+++ b/internal/theme/applier_test.go
@@ -1,6 +1,10 @@
-package theme
+package theme_test
 
-import "testing"
+import (
+	"testing"
+
+	"aether/internal/theme"
+)
 
 func TestNormalizeWallpaperBackend(t *testing.T) {
 	tests := []struct {
@@ -8,18 +12,19 @@ func TestNormalizeWallpaperBackend(t *testing.T) {
 		in   string
 		want string
 	}{
-		{name: "empty defaults to auto", in: "", want: WallpaperBackendAuto},
-		{name: "auto", in: "auto", want: WallpaperBackendAuto},
-		{name: "omarchy", in: "omarchy", want: WallpaperBackendOmarchy},
-		{name: "awww", in: "awww", want: WallpaperBackendAwww},
-		{name: "none", in: "none", want: WallpaperBackendNone},
-		{name: "case and space", in: " AWWW ", want: WallpaperBackendAwww},
-		{name: "unknown defaults to auto", in: "custom", want: WallpaperBackendAuto},
+		{name: "empty defaults to auto", in: "", want: theme.WallpaperBackendAuto},
+		{name: "auto", in: "auto", want: theme.WallpaperBackendAuto},
+		{name: "omarchy", in: "omarchy", want: theme.WallpaperBackendOmarchy},
+		{name: "awww", in: "awww", want: theme.WallpaperBackendAwww},
+		{name: "swaybg", in: "swaybg", want: theme.WallpaperBackendSwaybg},
+		{name: "none", in: "none", want: theme.WallpaperBackendNone},
+		{name: "case and space", in: " AWWW ", want: theme.WallpaperBackendAwww},
+		{name: "unknown defaults to auto", in: "custom", want: theme.WallpaperBackendAuto},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeWallpaperBackend(tt.in); got != tt.want {
+			if got := theme.NormalizeWallpaperBackend(tt.in); got != tt.want {
 				t.Fatalf("normalizeWallpaperBackend(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
@@ -30,69 +35,86 @@ func TestSelectWallpaperBackend(t *testing.T) {
 	tests := []struct {
 		name         string
 		requested    string
-		availability wallpaperBackendAvailability
+		availability theme.WallpaperBackendAvailability
 		want         string
 	}{
 		{
 			name:      "auto prefers omarchy",
-			requested: WallpaperBackendAuto,
-			availability: wallpaperBackendAvailability{
+			requested: theme.WallpaperBackendAuto,
+			availability: theme.WallpaperBackendAvailability{
 				Omarchy: true,
 				Awww:    true,
 			},
-			want: WallpaperBackendOmarchy,
+			want: theme.WallpaperBackendOmarchy,
 		},
 		{
 			name:      "auto falls back to awww",
-			requested: WallpaperBackendAuto,
-			availability: wallpaperBackendAvailability{
+			requested: theme.WallpaperBackendAuto,
+			availability: theme.WallpaperBackendAvailability{
 				Awww: true,
 			},
-			want: WallpaperBackendAwww,
+			want: theme.WallpaperBackendAwww,
+		},
+		{
+			name:      "auto falls back to swaybg",
+			requested: theme.WallpaperBackendAuto,
+			availability: theme.WallpaperBackendAvailability{
+				Swaybg: true,
+			},
+			want: theme.WallpaperBackendSwaybg,
 		},
 		{
 			name:      "auto skips when unavailable",
-			requested: WallpaperBackendAuto,
-			want:      WallpaperBackendNone,
+			requested: theme.WallpaperBackendAuto,
+			want:      theme.WallpaperBackendNone,
 		},
 		{
 			name:      "explicit awww wins",
-			requested: WallpaperBackendAwww,
-			availability: wallpaperBackendAvailability{
+			requested: theme.WallpaperBackendAwww,
+			availability: theme.WallpaperBackendAvailability{
 				Omarchy: true,
 			},
-			want: WallpaperBackendAwww,
+			want: theme.WallpaperBackendAwww,
 		},
 		{
-			name:      "explicit omarchy wins",
-			requested: WallpaperBackendOmarchy,
-			availability: wallpaperBackendAvailability{
-				Awww: true,
-			},
-			want: WallpaperBackendOmarchy,
-		},
-		{
-			name:      "explicit none wins",
-			requested: WallpaperBackendNone,
-			availability: wallpaperBackendAvailability{
+			name:      "explicit swaybg wins",
+			requested: theme.WallpaperBackendSwaybg,
+			availability: theme.WallpaperBackendAvailability{
 				Omarchy: true,
 				Awww:    true,
 			},
-			want: WallpaperBackendNone,
+			want: theme.WallpaperBackendSwaybg,
+		},
+		{
+			name:      "explicit omarchy wins",
+			requested: theme.WallpaperBackendOmarchy,
+			availability: theme.WallpaperBackendAvailability{
+				Awww: true,
+			},
+			want: theme.WallpaperBackendOmarchy,
+		},
+		{
+			name:      "explicit none wins",
+			requested: theme.WallpaperBackendNone,
+			availability: theme.WallpaperBackendAvailability{
+				Omarchy: true,
+				Awww:    true,
+			},
+			want: theme.WallpaperBackendNone,
 		},
 		{
 			name:      "unknown uses auto",
 			requested: "other",
-			availability: wallpaperBackendAvailability{
+			availability: theme.WallpaperBackendAvailability{
 				Awww: true,
 			},
-			want: WallpaperBackendAwww,
+			want: theme.WallpaperBackendAwww,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := selectWallpaperBackend(tt.requested, tt.availability); got != tt.want {
+			if got := theme.SelectWallpaperBackend(tt.requested, tt.availability); got != tt.want {
 				t.Fatalf("selectWallpaperBackend(%q, %+v) = %q, want %q", tt.requested, tt.availability, got, tt.want)
 			}
 		})

--- a/internal/theme/writer.go
+++ b/internal/theme/writer.go
@@ -169,9 +169,8 @@ func (w *Writer) ApplyTheme(state *ThemeState, settings Settings) (*ApplyResult,
 	if err := template.ProcessCustomApps(themeDir, variables); err != nil {
 		log.Printf("Warning: custom app processing failed: %v", err)
 	}
-	// Apply omarchy theme before wallpaper so that omarchy-theme-set's
-	// swaybg restart doesn't override aether-wp. For animated wallpapers,
-	// run synchronously so swaybg is fully started before we replace it.
+	// Apply Omarchy before wallpaper so omarchy-theme-set's wallpaper restart
+	// does not override aether-wp.
 	if isOmarchy {
 		sync := wallpaperDest != "" && IsAnimatedWallpaper(wallpaperDest)
 		if err := ApplyOmarchyTheme(sync); err != nil {

--- a/internal/theme/writer.go
+++ b/internal/theme/writer.go
@@ -34,6 +34,7 @@ var templateAppNameMap = map[string]string{
 	"vencord.theme.css": "vencord",
 	"warp.yaml":         "warp",
 	"colors.toml":       "colors",
+	"zellij.kdl":        "zellij",
 }
 
 // getAppNameFromFileName returns the app name for a given template file name.

--- a/internal/theme/writer.go
+++ b/internal/theme/writer.go
@@ -60,6 +60,7 @@ type Settings struct {
 	SelectedNeovimConfig string          `json:"selectedNeovimConfig"`
 	ExcludedApps         map[string]bool `json:"excludedApps,omitempty"`
 	VideoCpuMode         bool            `json:"videoCpuMode"`
+	WallpaperBackend     string          `json:"wallpaperBackend"`
 }
 
 // ApplyResult is returned by ApplyTheme with the outcome of theme application.

--- a/internal/theme/writer.go
+++ b/internal/theme/writer.go
@@ -27,6 +27,7 @@ var templateAppNameMap = map[string]string{
 	"mako.ini":          "mako",
 	"neovim.lua":        "neovim",
 	"swayosd.css":       "swayosd",
+	"triad.kdl":         "triad",
 	"walker.css":        "walker",
 	"waybar.css":        "waybar",
 	"wofi.css":          "wofi",

--- a/internal/theme/writer_test.go
+++ b/internal/theme/writer_test.go
@@ -30,3 +30,9 @@ func TestTriadTemplateRendersAccentColor(t *testing.T) {
 		t.Fatalf("rendered Triad template still has unresolved variable:\n%s", rendered)
 	}
 }
+
+func TestZellijTemplateMapsToZellijApp(t *testing.T) {
+	if got := GetAppNameFromFileName("zellij.kdl"); got != "zellij" {
+		t.Fatalf("GetAppNameFromFileName(zellij.kdl) = %q, want zellij", got)
+	}
+}

--- a/internal/theme/writer_test.go
+++ b/internal/theme/writer_test.go
@@ -1,0 +1,32 @@
+package theme
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"aether/internal/template"
+)
+
+func TestTriadTemplateRendersAccentColor(t *testing.T) {
+	if got := GetAppNameFromFileName("triad.kdl"); got != "triad" {
+		t.Fatalf("GetAppNameFromFileName(triad.kdl) = %q, want triad", got)
+	}
+
+	content, err := os.ReadFile("../../templates/triad.kdl")
+	if err != nil {
+		t.Fatalf("read triad template: %v", err)
+	}
+
+	rendered := template.ProcessTemplate(
+		string(content),
+		map[string]string{"accent": "#7fc8ff"},
+	)
+
+	if !strings.Contains(rendered, `accent-color "#7fc8ff"`) {
+		t.Fatalf("rendered Triad template does not contain accent color:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "{accent}") {
+		t.Fatalf("rendered Triad template still has unresolved variable:\n%s", rendered)
+	}
+}

--- a/internal/theme/writer_test.go
+++ b/internal/theme/writer_test.go
@@ -1,4 +1,4 @@
-package theme
+package theme_test
 
 import (
 	"os"
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"aether/internal/template"
+	"aether/internal/theme"
 )
 
 func TestTriadTemplateRendersAccentColor(t *testing.T) {
-	if got := GetAppNameFromFileName("triad.kdl"); got != "triad" {
+	if got := theme.GetAppNameFromFileName("triad.kdl"); got != "triad" {
 		t.Fatalf("GetAppNameFromFileName(triad.kdl) = %q, want triad", got)
 	}
 
@@ -32,7 +33,7 @@ func TestTriadTemplateRendersAccentColor(t *testing.T) {
 }
 
 func TestZellijTemplateMapsToZellijApp(t *testing.T) {
-	if got := GetAppNameFromFileName("zellij.kdl"); got != "zellij" {
+	if got := theme.GetAppNameFromFileName("zellij.kdl"); got != "zellij" {
 		t.Fatalf("GetAppNameFromFileName(zellij.kdl) = %q, want zellij", got)
 	}
 }

--- a/internal/themepack/manifest.go
+++ b/internal/themepack/manifest.go
@@ -1,0 +1,180 @@
+package themepack
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"aether/internal/blueprint"
+	"aether/internal/platform"
+)
+
+const (
+	Format        = "aether-theme-pack"
+	Version       = 1
+	ManifestFile  = "aether-theme-pack.json"
+	BlueprintFile = "blueprint.json"
+)
+
+// Manifest describes a portable Aether theme pack directory.
+type Manifest struct {
+	Format           string   `json:"format"`
+	Version          int      `json:"version"`
+	Name             string   `json:"name"`
+	Slug             string   `json:"slug"`
+	CreatedAt        string   `json:"createdAt"`
+	Apps             []string `json:"apps"`
+	LightMode        bool     `json:"lightMode"`
+	Wallpaper        string   `json:"wallpaper,omitempty"`
+	AdditionalImages []string `json:"additionalImages,omitempty"`
+	Blueprint        string   `json:"blueprint"`
+	Files            []string `json:"files"`
+}
+
+// NewManifest builds a pack manifest from generated files under dir.
+func NewManifest(dir, name, slug string, apps []string, lightMode bool, wallpaper string, images []string) (Manifest, error) {
+	files, err := listPackFiles(dir)
+	if err != nil {
+		return Manifest{}, err
+	}
+	sort.Strings(apps)
+	return Manifest{
+		Format:           Format,
+		Version:          Version,
+		Name:             name,
+		Slug:             slug,
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		Apps:             apps,
+		LightMode:        lightMode,
+		Wallpaper:        cleanRelative(wallpaper),
+		AdditionalImages: cleanRelativeSlice(images),
+		Blueprint:        BlueprintFile,
+		Files:            files,
+	}, nil
+}
+
+// Write stores the manifest and bundled blueprint in dir.
+func Write(dir string, manifest Manifest, bp *blueprint.Blueprint) error {
+	if err := platform.WriteJSON(filepath.Join(dir, BlueprintFile), bp); err != nil {
+		return err
+	}
+	manifest.Files = appendMissing(manifest.Files, BlueprintFile)
+	manifest.Files = appendMissing(manifest.Files, ManifestFile)
+	sort.Strings(manifest.Files)
+	return platform.WriteJSON(filepath.Join(dir, ManifestFile), manifest)
+}
+
+// Import reads a theme pack directory, manifest, or bundled blueprint file.
+func Import(path string) (*blueprint.Blueprint, error) {
+	dir, manifestPath, err := resolveInput(path)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := Manifest{Blueprint: BlueprintFile}
+	if manifestPath != "" {
+		if m, err := platform.ReadJSON[Manifest](manifestPath); err == nil {
+			manifest = m
+		}
+	}
+
+	blueprintPath := filepath.Join(dir, manifest.Blueprint)
+	if manifest.Blueprint == "" {
+		blueprintPath = filepath.Join(dir, BlueprintFile)
+	}
+	bp, err := blueprint.ImportJSON(blueprintPath)
+	if err != nil {
+		return nil, err
+	}
+	if bp.Name == "" && manifest.Name != "" {
+		bp.Name = manifest.Name
+	}
+
+	bp.Palette.Wallpaper = resolvePackPath(dir, bp.Palette.Wallpaper)
+	for i, p := range bp.Palette.AdditionalImages {
+		bp.Palette.AdditionalImages[i] = resolvePackPath(dir, p)
+	}
+	return bp, nil
+}
+
+func resolveInput(input string) (dir string, manifestPath string, err error) {
+	info, err := os.Stat(input)
+	if err != nil {
+		return "", "", err
+	}
+	if info.IsDir() {
+		dir = input
+	} else {
+		dir = filepath.Dir(input)
+		switch filepath.Base(input) {
+		case ManifestFile:
+			manifestPath = input
+		case BlueprintFile:
+			manifestPath = filepath.Join(dir, ManifestFile)
+		default:
+			return "", "", fmt.Errorf("not an Aether theme pack file: %s", input)
+		}
+	}
+	if manifestPath == "" {
+		candidate := filepath.Join(dir, ManifestFile)
+		if platform.FileExists(candidate) {
+			manifestPath = candidate
+		}
+	}
+	return dir, manifestPath, nil
+}
+
+func resolvePackPath(dir, p string) string {
+	if p == "" || filepath.IsAbs(p) || strings.HasPrefix(p, "http://") || strings.HasPrefix(p, "https://") {
+		return p
+	}
+	return filepath.Join(dir, filepath.FromSlash(p))
+}
+
+func listPackFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	return files, err
+}
+
+func cleanRelative(p string) string {
+	if p == "" {
+		return ""
+	}
+	return filepath.ToSlash(p)
+}
+
+func cleanRelativeSlice(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if p != "" {
+			out = append(out, cleanRelative(p))
+		}
+	}
+	return out
+}
+
+func appendMissing(items []string, item string) []string {
+	for _, existing := range items {
+		if existing == item {
+			return items
+		}
+	}
+	return append(items, item)
+}

--- a/internal/themepack/manifest_test.go
+++ b/internal/themepack/manifest_test.go
@@ -1,0 +1,60 @@
+package themepack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"aether/internal/blueprint"
+)
+
+func TestWriteAndImportThemePackResolvesRelativeWallpaper(t *testing.T) {
+	dir := t.TempDir()
+	bgDir := filepath.Join(dir, "backgrounds")
+	if err := os.MkdirAll(bgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wallpaper := filepath.Join(bgDir, "wallpaper.jpg")
+	if err := os.WriteFile(wallpaper, []byte("fake"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	bp := &blueprint.Blueprint{
+		Name: "test-pack",
+		Palette: blueprint.PaletteData{
+			Colors:           []string{"#000000", "#111111", "#222222", "#333333", "#444444", "#555555", "#666666", "#777777", "#888888", "#999999", "#aaaaaa", "#bbbbbb", "#cccccc", "#dddddd", "#eeeeee", "#ffffff"},
+			Wallpaper:        "backgrounds/wallpaper.jpg",
+			AdditionalImages: []string{"backgrounds/extra.png"},
+		},
+	}
+	manifest, err := NewManifest(dir, "Test Pack", "test-pack", []string{"triad", "zellij"}, false, "backgrounds/wallpaper.jpg", []string{"backgrounds/extra.png"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(dir, manifest, bp); err != nil {
+		t.Fatal(err)
+	}
+
+	imported, err := Import(filepath.Join(dir, ManifestFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imported.Palette.Wallpaper != wallpaper {
+		t.Fatalf("wallpaper = %q, want %q", imported.Palette.Wallpaper, wallpaper)
+	}
+	wantExtra := filepath.Join(dir, "backgrounds", "extra.png")
+	if got := imported.Palette.AdditionalImages[0]; got != wantExtra {
+		t.Fatalf("additional image = %q, want %q", got, wantExtra)
+	}
+}
+
+func TestImportRejectsUnrecognizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "other.json")
+	if err := os.WriteFile(path, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(path); err == nil {
+		t.Fatal("expected error for unrecognized file")
+	}
+}

--- a/internal/themepack/manifest_test.go
+++ b/internal/themepack/manifest_test.go
@@ -1,4 +1,4 @@
-package themepack
+package themepack_test
 
 import (
 	"os"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"aether/internal/blueprint"
+	"aether/internal/themepack"
 )
 
 func TestWriteAndImportThemePackResolvesRelativeWallpaper(t *testing.T) {
@@ -27,15 +28,15 @@ func TestWriteAndImportThemePackResolvesRelativeWallpaper(t *testing.T) {
 			AdditionalImages: []string{"backgrounds/extra.png"},
 		},
 	}
-	manifest, err := NewManifest(dir, "Test Pack", "test-pack", []string{"triad", "zellij"}, false, "backgrounds/wallpaper.jpg", []string{"backgrounds/extra.png"})
+	manifest, err := themepack.NewManifest(dir, "Test Pack", "test-pack", []string{"triad", "zellij"}, false, "backgrounds/wallpaper.jpg", []string{"backgrounds/extra.png"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Write(dir, manifest, bp); err != nil {
+	if err := themepack.Write(dir, manifest, bp); err != nil {
 		t.Fatal(err)
 	}
 
-	imported, err := Import(filepath.Join(dir, ManifestFile))
+	imported, err := themepack.Import(filepath.Join(dir, themepack.ManifestFile))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +55,7 @@ func TestImportRejectsUnrecognizedFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{}"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Import(path); err == nil {
+	if _, err := themepack.Import(path); err == nil {
 		t.Fatal("expected error for unrecognized file")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,17 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
+const (
+	defaultWindowWidth  = 1200
+	defaultWindowHeight = 960
+	minWindowWidth      = 960
+	minWindowHeight     = 640
+
+	// Wails/GTK on Linux turns a zero max size into the current monitor bounds,
+	// which makes a normal resizable app refuse larger compositor layouts later.
+	noPracticalWindowMax = 16384
+)
+
 func main() {
 	// GUI flags that need the full Wails runtime (not CLI-only)
 	guiFlags := map[string]bool{"--tab": true}
@@ -71,8 +82,12 @@ func main() {
 
 	err := wails.Run(&options.App{
 		Title:       "Aether",
-		Width:       900,
-		Height:      700,
+		Width:       defaultWindowWidth,
+		Height:      defaultWindowHeight,
+		MinWidth:    minWindowWidth,
+		MinHeight:   minWindowHeight,
+		MaxWidth:    noPracticalWindowMax,
+		MaxHeight:   noPracticalWindowMax,
 		StartHidden: true,
 		AssetServer: &assetserver.Options{
 			Assets: assets,

--- a/templates/triad.kdl
+++ b/templates/triad.kdl
@@ -1,0 +1,7 @@
+// This file is not a full Triad configuration.
+// Include it from ~/.config/triad/config.kdl:
+// include optional=#true "~/.config/aether/theme/triad.kdl"
+
+theme {
+    accent-color "{accent}"
+}


### PR DESCRIPTION
## Summary

First: thank you for Aether. The UI is beautiful, and the app already does a lot of hard things well: palette extraction, wallpaper editing, app templates, live preview, and exportable themes. It is one of the more polished theming tools I have used on Wayland.

I’m the author of [Triad](https://github.com/greenm01/triad), a programmable Wayland window manager for River. Its docs live in the [Triad wiki](https://github.com/greenm01/triad/wiki). I opened this PR because I wanted to help make Aether more Wayland-first while keeping Omarchy a first-class target.

I also created [aether-themes](https://github.com/greenm01/aether-themes) as a companion repo for portable Wayland theme packs. It currently includes Aura as an example pack adapted for Aether outside an Omarchy install.

The goal here is not to remove or weaken Omarchy support. It is to make the non-Omarchy path behave like a real supported path, rather than an accidental fallback.

## What Changed

- Added a Triad theme template.
- Added portable Aether theme-pack export/import metadata.
- Added support for discovering portable packs from `~/.config/themes`.
- Changed the System Themes picker so portable Aether packs apply through Aether’s normal template and wallpaper path.
- Kept `omarchy-theme-set` for real Omarchy themes.
- Hid Aether’s generated output from the picker so it does not shadow a real `aether` pack.
- Added explicit wallpaper backend settings: `auto`, `omarchy`, `awww`, `swaybg`, and `none`.
- Made `auto` prefer Omarchy when present, then `awww`, then `swaybg`.
- Stopped killing every `swaybg` process. Aether now tracks and stops only the one it started.
- Replaced unsafe symlink replacement with a helper that refuses to overwrite real files or directories.
- Fixed Linux window size hints so the app opens like a normal resizable desktop app.
- Updated docs and UI copy to describe Aether as Wayland-first and Omarchy-compatible.

## Why

A few paths still assumed Omarchy even when the UI was showing portable themes. That made theme packs look installed but fail or apply through the wrong mechanism.

The main example was the System Themes picker. A portable pack in `~/.config/themes` could show up next to Omarchy themes, but pressing Apply still called `omarchy-theme-set <name>`. This PR makes parsed Aether packs use Aether’s own apply path. Omarchy themes still use Omarchy.

There were also a couple of desktop footguns:

- the generated `~/.config/aether/theme` entry could appear as if it were a real installed theme;
- symlink creation could remove user-owned paths;
- static wallpaper apply used broad `pkill` behavior against `swaybg`.

Those are now tightened up.

## Tests

Passed locally:

```bash
GOCACHE=/tmp/aether-go-build go test ./...
npm --prefix frontend run check
```

I also moved the Go tests into external `_test` packages where practical, so they test exported behavior instead of package internals.
