### PR TITLE
Process custom apps in the Omarchy v4 branch

### DIFF
--- a/internal/theme/writer.go
+++ b/internal/theme/writer.go
@@ -238,6 +238,9 @@ func (w *Writer) ApplyTheme(state *ThemeState, settings Settings) (*ApplyResult,
 	variables := template.BuildVariables(state.ColorRoles, state.LightMode, state.ExtendedColors)
 	if isOmarchyV4 {
 		w.processOmarchyV4Templates(themeDir, variables, state.AppOverrides, state.ExtendedColors)
+		if err := template.ProcessCustomApps(themeDir, variables); err != nil {
+			log.Printf("Warning: custom app processing failed: %v", err)
+		}
 	} else {
 		w.processTemplates(variables, themeDir, settings, state.AppOverrides, state.ExtendedColors)
 		w.applyEditorThemes(themeDir, settings, variables)


### PR DESCRIPTION
## What

`ApplyTheme` only ran `template.ProcessCustomApps` in the pre-v4 path. On Omarchy v4 installs (`isOmarchyV4`), the dedicated v4 template renderer skipped it entirely, so any templates a user placed in `~/.config/aether/custom/` were silently never generated.

## Changes

`internal/theme/writer.go`: run `template.ProcessCustomApps(themeDir, variables)` in the v4 path too, with the same warning-on-failure handling as the legacy path.

## Verification

- `make test` passes (all internal + cli packages).
- `go vet` clean.
- Non-v4 behavior unchanged.
