### PR TITLE
Restore favorites for local wallpapers

### DIFF
--- a/frontend/src/lib/components/favorites/FavoritesView.svelte
+++ b/frontend/src/lib/components/favorites/FavoritesView.svelte
@@ -22,11 +22,14 @@
     import ViewHeader from '$lib/components/shared/ViewHeader.svelte';
     import {applyWallpaperOnly} from '$lib/actions/themeActions';
     import {getIsApplying} from '$lib/stores/theme.svelte';
-    import type {favorites as favoritesNs} from '../../../../wailsjs/go/models';
+    import {
+        getFavorites,
+        refreshFavorites,
+        toggleFavorite,
+        type Favorite,
+    } from '$lib/stores/favorites.svelte';
 
-    type Favorite = favoritesNs.Favorite;
-
-    let favorites = $state<Favorite[]>([]);
+    let favorites = $derived(getFavorites());
     let isLoading = $state(true);
     let filterTag = $state<string>('');
     let previewIndex = $state(-1);
@@ -45,17 +48,13 @@
         loadFavorites();
     });
 
+    // Re-sync with the backend on every mount so favourites added via the
+    // CLI/IPC while this tab was closed show up.
     async function loadFavorites() {
         isLoading = true;
         try {
-            const {GetFavorites} = await import(
-                '../../../../wailsjs/go/main/App'
-            );
-            const result = await GetFavorites();
-            favorites = Array.isArray(result) ? result : [];
+            await refreshFavorites();
             loadThumbnails();
-        } catch {
-            favorites = [];
         } finally {
             isLoading = false;
         }
@@ -103,12 +102,11 @@
 
     async function handleRemove(fav: Favorite) {
         try {
-            const {ToggleFavorite} = await import(
-                '../../../../wailsjs/go/main/App'
-            );
-            await ToggleFavorite(fav.path, fav.type ?? '', {});
-            favorites = favorites.filter(f => f.path !== fav.path);
-        } catch {}
+            await toggleFavorite(fav.path, fav.type ?? '');
+        } catch (err) {
+            console.error('ToggleFavorite failed', err);
+            showToast('Could not update favorites');
+        }
     }
 
     async function handleAddExtra(fav: Favorite) {
@@ -260,11 +258,13 @@
                         path={fav.path}
                         name={fav.data?.name || fav.data?.id || 'Wallpaper'}
                         isAdded={getAdditionalImages().includes(fav.path)}
+                        isFavorited={true}
                         applying={getIsApplying()}
                         onuse={() => handleSelect(fav)}
                         onwallpaperonly={() => applyWallpaperOnly(fav.path)}
                         onpreview={() => handlePreview(i)}
                         onaddextra={() => handleAddExtra(fav)}
+                        onfavorite={() => handleRemove(fav)}
                     >
                         {#snippet thumb()}
                             {#if getCachedThumbnail(fav.path)}
@@ -278,27 +278,6 @@
                                     >...</span
                                 >
                             {/if}
-                        {/snippet}
-                        {#snippet topRight()}
-                            <button
-                                class="absolute right-1.5 top-1.5 z-10 flex h-7 w-7 items-center justify-center opacity-100"
-                                onclick={() => handleRemove(fav)}
-                                aria-label="Remove from favorites"
-                            >
-                                <svg
-                                    class="text-destructive h-4 w-4"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    stroke="currentColor"
-                                    stroke-width="2"
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                >
-                                    <path
-                                        d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
-                                    ></path>
-                                </svg>
-                            </button>
                         {/snippet}
                     </WallpaperTile>
                 {/each}

--- a/frontend/src/lib/components/local/LocalBrowser.svelte
+++ b/frontend/src/lib/components/local/LocalBrowser.svelte
@@ -17,6 +17,7 @@
         loadFullImage,
         getCachedFullImage,
     } from '$lib/stores/imagecache.svelte';
+    import {isFavorite, toggleFavorite} from '$lib/stores/favorites.svelte';
     import LazyImage from '$lib/components/shared/LazyImage.svelte';
     import WallpaperTile from '$lib/components/shared/WallpaperTile.svelte';
     import ImagePreview from '$lib/components/shared/ImagePreview.svelte';
@@ -89,7 +90,9 @@
         } catch (err) {
             wallpapers = [];
             loadError =
-                err instanceof Error ? err.message : 'Wallpaper folder unavailable';
+                err instanceof Error
+                    ? err.message
+                    : 'Wallpaper folder unavailable';
         } finally {
             isLoading = false;
         }
@@ -184,6 +187,20 @@
         }
         addAdditionalImage(path);
         showToast('Added to additional images');
+    }
+
+    async function handleFavorite(wp: Wallpaper) {
+        try {
+            const nowFavorited = await toggleFavorite(wp.path, 'local', {
+                name: wp.name,
+            });
+            showToast(
+                nowFavorited ? 'Added to favorites' : 'Removed from favorites'
+            );
+        } catch (err) {
+            console.error('ToggleFavorite failed', err);
+            showToast('Could not update favorites');
+        }
     }
 
     async function handlePreview(index: number) {
@@ -371,11 +388,13 @@
                         path={wp.path}
                         name={wp.name}
                         isAdded={getAdditionalImages().includes(wp.path)}
+                        isFavorited={isFavorite(wp.path)}
                         applying={getIsApplying()}
                         onuse={() => selectWallpaper(wp.path)}
                         onwallpaperonly={() => applyWallpaperOnly(wp.path)}
                         onpreview={() => handlePreview(i)}
                         onaddextra={() => handleAddExtra(wp.path)}
+                        onfavorite={() => handleFavorite(wp)}
                     >
                         {#snippet thumb()}
                             <LazyImage path={wp.path} alt={wp.name} />

--- a/frontend/src/lib/components/shared/WallpaperTile.svelte
+++ b/frontend/src/lib/components/shared/WallpaperTile.svelte
@@ -4,31 +4,33 @@
 
     // Shared card for the Local and Favorites wallpaper grids. The thumbnail
     // source differs per view (lazy-loaded vs preloaded cache), so it arrives
-    // as a `thumb` snippet; `topRight` is an optional slot for view-specific
-    // actions (e.g. the favourites remove button). Clicking the thumbnail or
-    // the Use button selects the wallpaper.
+    // as a `thumb` snippet. The favourite heart renders only when `onfavorite`
+    // is supplied. Clicking the thumbnail or the Use button selects the
+    // wallpaper.
     let {
         path,
         name,
         isAdded = false,
+        isFavorited = false,
         applying = false,
         onuse,
         onwallpaperonly,
         onpreview,
         onaddextra,
+        onfavorite,
         thumb,
-        topRight,
     }: {
         path: string;
         name: string;
         isAdded?: boolean;
+        isFavorited?: boolean;
         applying?: boolean;
         onuse: () => void;
         onwallpaperonly: () => void;
         onpreview: () => void;
         onaddextra: () => void;
+        onfavorite?: () => void;
         thumb: Snippet;
-        topRight?: Snippet;
     } = $props();
 </script>
 
@@ -73,8 +75,36 @@
         </svg>
     </button>
 
-    {#if topRight}
-        {@render topRight()}
+    {#if onfavorite}
+        <button
+            class="absolute right-1.5 top-1.5 z-10 flex h-7 w-7 items-center justify-center transition-all duration-150
+            {isFavorited
+                ? 'opacity-100'
+                : 'opacity-0 hover:!opacity-100 group-hover:opacity-60'}"
+            onclick={e => {
+                e.stopPropagation();
+                onfavorite();
+            }}
+            aria-label={isFavorited
+                ? 'Remove from favorites'
+                : 'Add to favorites'}
+        >
+            <svg
+                class="h-4 w-4 {isFavorited
+                    ? 'text-destructive'
+                    : 'text-white'}"
+                viewBox="0 0 24 24"
+                fill={isFavorited ? 'currentColor' : 'none'}
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+            >
+                <path
+                    d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+                ></path>
+            </svg>
+        </button>
     {/if}
 
     <div

--- a/frontend/src/lib/components/wallhaven/WallpaperCard.svelte
+++ b/frontend/src/lib/components/wallhaven/WallpaperCard.svelte
@@ -9,40 +9,28 @@
     import {getIsApplying} from '$lib/stores/theme.svelte';
     import {openURL} from '$lib/utils/browser';
     import {observeIntersection} from '$lib/utils/intersection';
+    import {isFavorite, toggleFavorite} from '$lib/stores/favorites.svelte';
 
     let {wallpaper, onpreview}: {wallpaper: any; onpreview: () => void} =
         $props();
     let isDownloading = $state(false);
-    let isFavorited = $state(false);
+    let favoriteKey = $derived(wallpaper.path || wallpaper.id);
+    let isFavorited = $derived(isFavorite(favoriteKey));
     let cardEl = $state<HTMLDivElement | null>(null);
     let inView = $state(false);
-    let favoriteChecked = false;
 
-    // Gate <img> and the IsFavorite IPC call on viewport so scrolled-past
-    // cards release decoded-image memory and never-visible cards skip IPC.
+    // Gate <img> on viewport so scrolled-past cards release decoded-image
+    // memory.
     $effect(() => {
         if (!cardEl) return;
         return observeIntersection(
             cardEl,
             entry => {
                 inView = entry.isIntersecting;
-                if (inView && !favoriteChecked) {
-                    favoriteChecked = true;
-                    checkFavorite();
-                }
             },
             {rootMargin: '600px 0px'}
         );
     });
-
-    async function checkFavorite() {
-        try {
-            const {IsFavorite} = await import(
-                '../../../../wailsjs/go/main/App'
-            );
-            isFavorited = await IsFavorite(wallpaper.path || wallpaper.id);
-        } catch {}
-    }
 
     async function handleUse() {
         isDownloading = true;
@@ -64,20 +52,15 @@
     async function handleFavorite(event: MouseEvent) {
         event.stopPropagation();
         try {
-            const {ToggleFavorite} = await import(
-                '../../../../wailsjs/go/main/App'
-            );
-            const result = await ToggleFavorite(
-                wallpaper.path || wallpaper.id,
-                'wallhaven',
-                {
-                    id: wallpaper.id,
-                    thumbUrl: wallpaper.thumbs?.small,
-                    resolution: wallpaper.resolution,
-                }
-            );
-            isFavorited = result;
-        } catch {}
+            await toggleFavorite(favoriteKey, 'wallhaven', {
+                id: wallpaper.id,
+                thumbUrl: wallpaper.thumbs?.small,
+                resolution: wallpaper.resolution,
+            });
+        } catch (err) {
+            console.error('ToggleFavorite failed', err);
+            showToast('Could not update favorites');
+        }
     }
 
     async function handleAddExtra(event: MouseEvent) {

--- a/frontend/src/lib/stores/favorites.svelte.ts
+++ b/frontend/src/lib/stores/favorites.svelte.ts
@@ -1,0 +1,49 @@
+// Favorited wallpapers (local files and wallhaven), backed by the Go
+// favorites service. Held in one place so the Local grid can show heart
+// state without an IPC round-trip per card, and so toggling from any tab
+// keeps the others in sync.
+
+import type {favorites as favoritesNs} from '../../../wailsjs/go/models';
+
+export type Favorite = favoritesNs.Favorite;
+
+let favorites = $state<Favorite[]>([]);
+let pathSet = $derived(new Set(favorites.map(f => f.path)));
+
+refreshFavorites();
+
+export async function refreshFavorites(): Promise<void> {
+    try {
+        const {GetFavorites} = await import('../../../wailsjs/go/main/App');
+        const result = await GetFavorites();
+        favorites = Array.isArray(result) ? result : [];
+    } catch {
+        favorites = [];
+    }
+}
+
+export function getFavorites(): Favorite[] {
+    return favorites;
+}
+
+export function isFavorite(path: string): boolean {
+    return pathSet.has(path);
+}
+
+// Adds or removes `path`; resolves to the new favorited state. `data` is
+// only used when adding (see favorites.Service.buildEntry for the shape
+// each type accepts).
+export async function toggleFavorite(
+    path: string,
+    type: string,
+    data: Record<string, unknown> = {}
+): Promise<boolean> {
+    const {ToggleFavorite} = await import('../../../wailsjs/go/main/App');
+    const nowFavorited = await ToggleFavorite(path, type, data);
+    if (nowFavorited) {
+        if (!pathSet.has(path)) favorites = [...favorites, {path, type, data}];
+    } else {
+        favorites = favorites.filter(f => f.path !== path);
+    }
+    return nowFavorited;
+}


### PR DESCRIPTION
## Summary

Local wallpapers can't be favorited since the 4.0.0 rewrite. The Go favorites service still handles `type: "local"` and `FavoritesView` still renders them (its empty state even says "Tap the heart on any wallpaper in Wallhaven or Local"), but `LocalBrowser` never got a heart button.

- New `stores/favorites.svelte.ts`: one reactive favorites list; `isFavorite()` / `toggleFavorite()` / `refreshFavorites()`. Lets the Local grid show heart state without an `IsFavorite` IPC call per card (relevant at 10k+ wallpapers).
- `WallpaperTile` gets `isFavorited` / `onfavorite` props and renders the same heart as `WallpaperCard`. The `topRight` snippet, which only existed for the Favorites remove button, is dropped.
- `LocalBrowser` wires the heart (`ToggleFavorite(path, "local", {name})`).
- `FavoritesView` and `WallpaperCard` read/toggle through the store so all three tabs stay in sync. `FavoritesView` still refreshes from the backend on mount.

No Go changes.

## Testing

- `svelte-check`: 0 errors
- `wails dev`: hearted a local wallpaper, confirmed it appears in Favorites, removed it from Favorites, confirmed the Local heart cleared; persists across restart