### PR TITLE
Accept 8-digit hex colors with alpha in blueprint validation

### DIFF
--- a/internal/color/validate.go
+++ b/internal/color/validate.go
@@ -1,8 +1,11 @@
 package color
 
-// IsHexColor reports whether value is a safe three- or six-digit hex color.
+// IsHexColor reports whether value is a safe 3-, 4-, 6-, or 8-digit hex color.
+// Eight-digit form is #RRGGBBAA (used by templates such as aether.zed.json).
 func IsHexColor(value string) bool {
-	if len(value) != 4 && len(value) != 7 {
+	switch len(value) {
+	case 4, 5, 7, 9:
+	default:
 		return false
 	}
 	if value[0] != '#' {

--- a/internal/color/validate_test.go
+++ b/internal/color/validate_test.go
@@ -1,0 +1,21 @@
+package color
+
+import "testing"
+
+func TestIsHexColor(t *testing.T) {
+	cases := map[string]bool{
+		"#fff":       true,
+		"#ffffff":    true,
+		"#ffffffff":  true,
+		"#FFFF":      true,
+		"#ggg":       false,
+		"#fffffff":   false,
+		"ffffff":     false,
+		"":           false,
+	}
+	for in, want := range cases {
+		if got := IsHexColor(in); got != want {
+			t.Fatalf("IsHexColor(%q)=%v want %v", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Templates already use `#RRGGBBAA`, but validation rejected anything longer than `#RRGGBB`.
- Accept 3/4/6/8-digit hex and cover it with a unit test.

## Test plan
- [ ] `go test ./internal/color/...`
- [ ] Import a blueprint that uses `#00000000`